### PR TITLE
Some cleanup in the documentation

### DIFF
--- a/additional-material/additional-material.md
+++ b/additional-material/additional-material.md
@@ -1,9 +1,11 @@
 # Additional information
 
-### [ Keeping your fork synced with the repository ](keeping-your-fork-synced-with-this-repository.md)
-This document provides information about how to keep your forked repository up-to-date with the base repository.
-> Follow these steps if your fork doesn't have any changes in parent repository.
+We assume that you have already finished with the basic tutorial before coming here. The additional information will give you some information about advanced Git techniques. 
 
 ### [ Removing branch from your repository ](removing-branch-from-your-repository.md)
 This document provides information about how to delete a branch from your repository.
 > Only do these steps after your pull request get's merged.
+
+### [ Keeping your fork synced with the repository ](keeping-your-fork-synced-with-this-repository.md)
+This document provides information about how to keep your forked repository up-to-date with the base repository. This is important, as hopefully you and many others will contribute to the project.
+> Follow these steps if your fork doesn't have any changes in parent repository.

--- a/additional-material/keeping-your-fork-synced-with-this-repository.md
+++ b/additional-material/keeping-your-fork-synced-with-this-repository.md
@@ -3,7 +3,7 @@
 First, the flow for a full sync should be understood. In this schema, there are 3 different repos: my public repo on Github `github.com/Roshanjossey/first-contributions/`, your fork of the repo on GitHub `github.com/Your-Name/first-contributions/` and your local machine's repo from which you are suppose to work. 
 
 To keep your two repos up-to-date with my public repo, our first move is to fetch and merge the public repo with your local machine's repo.
-Our second move will be to push your local repo to your GitHub fork. As you've seen earlier, it's only from your fork that you can ask for a "pull request". So your GitHub fork is the last repo to be updated. (A drawing should be inserted here for clarity)
+Our second move will be to push your local repo to your GitHub fork. As you've seen earlier, it's only from your fork that you can ask for a "pull request". So your GitHub fork is the last repo to be updated.
 
 Now, let's see how to do it:
 

--- a/additional-material/removing-branch-from-your-repository.md
+++ b/additional-material/removing-branch-from-your-repository.md
@@ -1,5 +1,3 @@
-Now, your `<add-your-name>` branch has finished it's purpose, so let's see how to remove this branch. 
-
 ## Remove a branch from your repository
 
 If you have followed the tutorial up-to-now, our `<add-your-name>` branch has finished it's purpose, it is time to delete it from your local machine's repo. This isn't necessary, but the name of this branch shows its rather special purpose.  Its life can be made correspondingly short. 


### PR DESCRIPTION
Added some clarification to the start of additional-material.md
Switched keeping-your-fork-synced-with-this-repository and removing-branch-from-your-repository in the links. This seems to represent the workflow better.
Removed the request for a drawing from keeping-your-fork-synced-with-this-repository and made it to an issue. (#657)