### PR TITLE
Change translated languages list format in README.md

### DIFF
--- a/LANGUAGES.md
+++ b/LANGUAGES.md
@@ -1,0 +1,25 @@
+# Translation
+
+| Country | Translated Link |
+| --- | --- |
+| English | [English](README.md) |
+| 🇮🇳 India | [Hindi](translations/README.hi.md) |
+| 🇲🇲 Myanmar | [Myanmar Unicode](translations/README.mm_unicode.md) |
+| 🇮🇩 Indonesian | [Indonesian](translations/README.id.md) |
+| 🇫🇷 French | [French](translations/README.fr.md) |
+| 🇪🇸 Spain | [Spanish](translations/README.es.md) |
+| 🇳🇱 Dutch | [Dutch](translations/README.nl.md) |
+| 🇷🇺 Russian | [Russian](translations/README.ru.md) |
+| 🇯🇵 Japan | [Japanese](translations/README.ja.md) |
+| 🇻🇳 Vietnam | [Vietnamese](translations/README.vn.md) |
+| 🇵🇱 Poland | [Polish](translations/README.pl.md) |
+| 🇰🇷 South Korea, 🇰🇵 North Korea | [Korean](translations/README.ko.md) |
+| 🇩🇪 Germany | [German](translations/README.de.md) |
+| 🇨🇳 China | [Simplified Chinese](translations/README.chs.md), [Traditional Chinese](translations/README.cht.md) |
+| 🇬🇷 Greece | [Greek](translations/README.gr.md) |
+| العربية | [العربية](translations/README.ar.md) |
+| 🇺🇦 Ukraine | [Ukrainian](translations/README.ua.md) |
+| 🇵🇹 Portugal, 🇧🇷 Brazil | [Português/Brasil](translations/README.pt_br.md) |
+| 🇮🇹 Italy | [Italian](translations/README.it.md)
+| 🇹🇭 Thailand | [ภาษาไทย](translations/README.th.md) |
+| 🏴󠁥󠁳󠁧󠁡󠁿 Galicia | [Galician](translations/README.gl.md) |

--- a/README.md
+++ b/README.md
@@ -9,30 +9,7 @@ It's hard. It's always hard the first time you do something. Especially when you
 
 Reading articles & watching tutorials can help, but what's better than actually doing the stuff without messing up anything? This project aims at providing guidance & simplifying the way rookies make their first contribution. Remember: the more relaxed you are, the better you learn. If you are looking to make your first contribution, just follow the simple steps below. We promise you, it will be fun.
 
-#### *Read this in other languages:* 
-
-| Country | Translated Link |
-| --- | --- |
-| 🇮🇳 India | [Hindi](translations/README.hi.md) |
-| 🇲🇲 Myanmar | [Myanmar Unicode](translations/README.mm_unicode.md) |
-| 🇮🇩 Indonesian | [Indonesian](translations/README.id.md) |
-| 🇫🇷 French | [French](translations/README.fr.md) |
-| 🇪🇸 Spain | [Spanish](translations/README.es.md) |
-| 🇳🇱 Dutch | [Dutch](translations/README.nl.md) |
-| 🇷🇺 Russian | [Russian](translations/README.ru.md) |
-| 🇯🇵 Japan | [Japanese](translations/README.ja.md) |
-| 🇻🇳 Vietnam | [Vietnamese](translations/README.vn.md) |
-| 🇵🇱 Poland | [Polish](translations/README.pl.md) |
-| 🇰🇷 South Korea, 🇰🇵 North Korea | [Korean](translations/README.ko.md) |
-| 🇩🇪 Germany | [German](translations/README.de.md) |
-| 🇨🇳 China | [Simplified Chinese](translations/README.chs.md), [Traditional Chinese](translations/README.cht.md) |
-| 🇬🇷 Greece | [Greek](translations/README.gr.md) |
-| العربية | [العربية](translations/README.ar.md) |
-| 🇺🇦 Ukraine | [Ukrainian](translations/README.ua.md) |
-| 🇵🇹 Portugal, 🇧🇷 Brazil | [Português/Brasil](translations/README.pt_br.md) |
-| 🇮🇹 Italy | [Italian](translations/README.it.md)
-| 🇹🇭 Thailand | [ภาษาไทย](translations/README.th.md) |
-| 🏴󠁥󠁳󠁧󠁡󠁿 Galicia | [Galician](translations/README.gl.md) |
+#### *Read this in [other languages](LANGUAGES.md)* 
 
 <img align="right" width="300" src="assets/fork.png" alt="fork this repository" />
 

--- a/README.md
+++ b/README.md
@@ -9,9 +9,32 @@ It's hard. It's always hard the first time you do something. Especially when you
 
 Reading articles & watching tutorials can help, but what's better than actually doing the stuff without messing up anything? This project aims at providing guidance & simplifying the way rookies make their first contribution. Remember: the more relaxed you are, the better you learn. If you are looking to make your first contribution, just follow the simple steps below. We promise you, it will be fun.
 
-<img align="right" width="300" src="assets/fork.png" alt="fork this repository" />
+#### *Read this in other languages:* 
 
-*Read this in other languages: [Myanmar Unicode](translations/README.mm_unicode.md),  [Indonesian](translations/README.id.md), [French](translations/README.fr.md), [Spanish](translations/README.es.md), [Dutch](translations/README.nl.md), [Hindi](translations/README.hi.md), [Russian](translations/README.ru.md), [Japanese](translations/README.ja.md), [Vietnamese](translations/README.vn.md), [Polish](translations/README.pl.md), [Korean](translations/README.ko.md), [German](translations/README.de.md), [Simplified Chinese](translations/README.chs.md), [Traditional Chinese](translations/README.cht.md), [Greek](translations/README.gr.md), [العربية](translations/README.ar.md), [Ukrainian](translations/README.ua.md), [Português/Brasil](translations/README.pt_br.md), [Italian](translations/README.it.md), [ภาษาไทย](translations/README.th.md) and [Galician](translations/README.gl.md).*
+| Country | Translated Link |
+| --- | --- |
+| 🇮🇳 India | [Hindi](translations/README.hi.md) |
+| 🇲🇲 Myanmar | [Myanmar Unicode](translations/README.mm_unicode.md) |
+| 🇮🇩 Indonesian | [Indonesian](translations/README.id.md) |
+| 🇫🇷 French | [French](translations/README.fr.md) |
+| 🇪🇸 Spain | [Spanish](translations/README.es.md) |
+| 🇳🇱 Dutch | [Dutch](translations/README.nl.md) |
+| 🇷🇺 Russian | [Russian](translations/README.ru.md) |
+| 🇯🇵 Japan | [Japanese](translations/README.ja.md) |
+| 🇻🇳 Vietnam | [Vietnamese](translations/README.vn.md) |
+| 🇵🇱 Poland | [Polish](translations/README.pl.md) |
+| 🇰🇷 South Korea, 🇰🇵 North Korea | [Korean](translations/README.ko.md) |
+| 🇩🇪 Germany | [German](translations/README.de.md) |
+| 🇨🇳 China | [Simplified Chinese](translations/README.chs.md), [Traditional Chinese](translations/README.cht.md) |
+| 🇬🇷 Greece | [Greek](translations/README.gr.md) |
+| العربية | [العربية](translations/README.ar.md) |
+| 🇺🇦 Ukraine | [Ukrainian](translations/README.ua.md) |
+| 🇵🇹 Portugal, 🇧🇷 Brazil | [Português/Brasil](translations/README.pt_br.md) |
+| 🇮🇹 Italy | [Italian](translations/README.it.md)
+| 🇹🇭 Thailand | [ภาษาไทย](translations/README.th.md) |
+| 🏴󠁥󠁳󠁧󠁡󠁿 Galicia | [Galician](translations/README.gl.md) |
+
+<img align="right" width="300" src="assets/fork.png" alt="fork this repository" />
 
 If you don't have git on your machine, [ install it ]( https://help.github.com/articles/set-up-git/ ).
 


### PR DESCRIPTION
I changed translated language list `inline` to `table` with country flags and country name for #780 .

#### Example
|Country | Translated Link |
| --- | --- |
| 🇮🇳 India | [Hindi](https://github.com/Roshanjossey/first-contributions/blob/master/translations/README.hi.md) |
| 🇲🇲 Myanmar | [Myanmar Unicode](https://github.com/Roshanjossey/first-contributions/blob/master/translations/README.mm_unicode.md)  |

## TODO
- [x] Need to create translated link file. Plz choice one or any suggest name -
 - `TRANSLATED_LINK.md`
 - `translated_link.md`

## Note
All of flags are using from [Emojipedia](https://emojipedia.org).