### PR TITLE
Add link to contribute-to-open-source

### DIFF
--- a/app/src/components/ProjectList/listOfProjects.js
+++ b/app/src/components/ProjectList/listOfProjects.js
@@ -149,6 +149,7 @@ const projectList = [
     imageSrc: 'https://image.ibb.co/fUM5oG/profile_first_pr.png',
     githubLink: 'https://github.com/danthareja/contribute-to-open-source',
     description: 'Learn GitHub\'s pull request process by contributing code in a fun simulation project ',
+    tag: ['GitHub', 'tutorial'],
   },
 ];
 

--- a/app/src/components/ProjectList/listOfProjects.js
+++ b/app/src/components/ProjectList/listOfProjects.js
@@ -144,6 +144,11 @@ const projectList = [
     imageSrc: 'https://github.com/Semantic-Org/Semantic-UI-React/raw/master/docs/app/logo.png',
     githubLink: 'https://github.com/Semantic-Org/Semantic-UI-React/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22',
     description: 'The official Semantic-UI-React integration',
+  }, {
+    name: 'Contribute to Open Source',
+    imageSrc: 'https://image.ibb.co/fUM5oG/profile_first_pr.png',
+    githubLink: 'https://github.com/danthareja/contribute-to-open-source',
+    description: 'Learn GitHub\'s pull request process by contributing code in a fun simulation project ',
   },
 ];
 


### PR DESCRIPTION
Hey there!

I recently released a project that aims to empower new contributors by teaching them the mechanics of the GitHub pull request process in an interactive experience.

https://github.com/danthareja/contribute-to-open-source

In this project, users are given tests and tasked with writing code to DRY up an existing codebase. When they submit a PR, there's some fun back and forth with a bot that interprets their CI results and eventually merges their code.

I'd like to increase exposure to this project to as many new contributors as possible, and thought it would make a nice addition to this page.