### PR TITLE
Fixing Markdown lint warnings

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -1994,3 +1994,4 @@
 - [Assa Schneider] (https://github.com/AssaSch)
 - [Jordan Skophammer] (https://github.com/skop22)
 - [Spencer Wolf] (https://github.com/spwolf22)
+- [David Deng] (https://github.com/PROgram52bc)

--- a/Contributors.md
+++ b/Contributors.md
@@ -1995,3 +1995,4 @@
 - [Jordan Skophammer] (https://github.com/skop22)
 - [Spencer Wolf] (https://github.com/spwolf22)
 - [David Deng] (https://github.com/PROgram52bc)
+- [Linh Huynh] (https://github.com/linh4)

--- a/additional-material/Useful-links-for-further-learning.md
+++ b/additional-material/Useful-links-for-further-learning.md
@@ -18,5 +18,6 @@ This document is dedicated to all the blog posts, helpful sites, tips and tricks
 13. [How to contribute](https://opensource.guide/how-to-contribute/)
 14. [Getting started with Open Source](https://github.com/OpenSourceHelpCommunity/Getting-Started-With-Contributing-to-Open-Sources)
 15. [How to contribute](https://github.com/freeCodeCamp/how-to-contribute-to-open-source)
+16. [Atlassians Git Tutorials](https://www.atlassian.com/git)
 
 Keep adding more links, that you find helpful.

--- a/additional-material/translations/additional-material.ko.md
+++ b/additional-material/translations/additional-material.ko.md
@@ -2,42 +2,41 @@
 
 여러분이 여기에 오기 전에 기본실습 과정을 이미 완료했다고 가정합니다. 이곳에서는 고급 Git 기술에 대한 정보를 제공합니다.
 
-### [ 여러분의 저장소에서 브랜치 삭제하기 ](removing-branch-from-your-repository.ko.md)
+### [여러분의 저장소에서 브랜치 삭제하기](removing-branch-from-your-repository.ko.md)
 이 문서는 저장소에서 브랜치를 삭제하는 방법에 대한 정보를 제공합니다.
 > PR(pull request) 요청이 병합 된 후에 본 단계를 수행하십시오.
 
-### [ 여러분이 포크한 저장소와 싱크상태 유지하기 ](keeping-your-fork-synced-with-this-repository.ko.md)
+### [여러분이 포크한 저장소와 싱크상태 유지하기](keeping-your-fork-synced-with-this-repository.ko.md)
 이 문서는 포크 된 저장소를 기본 저장소로 최신 상태로 유지하는 방법에 대한 정보를 제공합니다. 여러분과 다른 많은 사람들이 프로젝트에 기여하기를 바랍니다.
 > 포크 된 상위 저장소가 변경되지 않은 경우 다음 단계를 수행하십시오.
 
-### [ 커밋 되돌리기 ](reverting-a-commit.ko.md)
+### [커밋 되돌리기](reverting-a-commit.ko.md)
 이 문서는 원격 저장소에서 커밋을 되돌리는 방법에 대한 정보를 제공합니다. 이미 Github에 푸시 된 커밋을 되돌리려는 경우 유용합니다.
 > 커밋을 되돌리려면 이 단계를 수행하십시오.
 
-### [ 커밋 수정하기 ](amending-a-commit.ko.md)
+### [커밋 수정하기](amending-a-commit.ko.md)
 이 문서는 원격 저장소에서 커밋을 수정하는 방법에 대한 정보를 제공합니다.
 > 당신이 만든 커밋을 수정해야 할 때 사용하십시오.
 
-### [ 로컬 커밋 되돌리기 ](undoing-a-commit.ko.md)
+### [로컬 커밋 되돌리기](undoing-a-commit.ko.md)
 이 문서는 로컬 저장소에서 커밋을 실행 취소하는 방법에 대한 정보를 제공합니다. 로컬 저장소가 엉망이라고 느껴 당신이 로컬 저장소를 리셋하고자 할 때 당신이 해야 할 일입니다.
 > 로컬 커밋을 취소하려면 이 단계를 수행하십시오.
 
-### [ 병합 충돌 해결하기 ](resolving-merge-conflicts.ko.md)
+### [병합 충돌 해결하기](resolving-merge-conflicts.ko.md)
 이 문서는 병합 충돌을 해결하는 방법에 대한 정보를 제공합니다.
 > 이 단계를 수행하여 곤란한 병합 충돌을 해결하십시오.
 
-### [ 커밋을 다른 브랜치로 이동하기 ](moving-a-commit-to-a-different-branch.ko.md)
+### [커밋을 다른 브랜치로 이동하기](moving-a-commit-to-a-different-branch.ko.md)
 이 문서는 커밋을 다른 브랜치로 이동하는 방법에 대한 정보를 제공합니다.
 > 이 단계를 수행하여 커밋을 다른 브랜치로 이동하십시오.
 
-### [ git 설정하기 ](../configuring-git.md)
+### [git 설정하기](../configuring-git.md)
 이 문서는 git에서 사용자 정보 및 기타 옵션을 구성하는 방법에 대한 정보를 제공합니다.
 > git 설정을 더 잘 다루려면 이 단계를 수행하십시오.
 
-### [ 유용한 링크 ](../Useful-links-for-further-learning.md)
+### [유용한 링크](../Useful-links-for-further-learning.md)
 이 문서는 모든 블로그 게시물, 유용한 사이트, 유용한 정보 및 웹 사이트에 대한 내용을 담고 있습니다. 우리가 모든 필요를 위해 참조하는 것은 초심자 또는 전문가 일 것입니다. 이 페이지는 오픈 소스 도메인을 처음 접하거나 더 많은 것을 배우고자 하는 사람들을 돕는 지표 역할을 해야 합니다.
 
-### [ 스쿼시 커밋하기 ](../squashing-commits.md)
+### [스쿼시 커밋하기](../squashing-commits.md)
 이 문서는 대화형 리베이스로 커밋을 스쿼시하는 방법에 대한 정보를 제공합니다.
 > 오픈 소스 프로젝트에서 PR을 보낼 때 리뷰어가 모든 커밋을 하나로 스쿼시하도록 요청하는 경우 유익한 커밋 메시지와 함께 이것을 사용하십시오.
-

--- a/additional-material/translations/additional-material.pt_br.md
+++ b/additional-material/translations/additional-material.pt_br.md
@@ -2,10 +2,10 @@
 
 Nós estamos assumindo que você já terminou o tutorial básico antes de vir aqui. As informações adicionais te darão algumas informações sobre técnicas avançadas de Git.
 
-### [ Removendo o Branch do seu repositório ](removing-branch-from-your-repository.pt_br.md)
+### [Removendo o Branch do seu repositório](removing-branch-from-your-repository.pt_br.md)
 Esse documento fornece informações sobre como deletar o Branch do seu repositório.
 > Só siga esses passos depois que seu Pull Request for mesclado.
 
-### [ Mantendo o seu Fork sincronizado com este repositório ](keeping-your-fork-synced-with-this-repository.pt_br.md)
+### [Mantendo o seu Fork sincronizado com este repositório](keeping-your-fork-synced-with-this-repository.pt_br.md)
 Esse documento fornece informações sobre como manter seu Fork atualizado com o repositório base. Isso é importante, já que esperamos que você e muitos outros contribuam com este projeto.
 > Só siga esses passos se seu Fork não tiver nenhuma alteração.

--- a/additional-material/translations/addtional-material.cht.md
+++ b/additional-material/translations/addtional-material.cht.md
@@ -2,27 +2,27 @@
 
 我們認為你在來到這裡以前已經完成基本教學。附加資料會給你關於 Git 進階技術的資訊。
 
-### [ 從你的 repository 刪除分支 ](../removing-branch-from-your-repository.md)
+### [從你的 repository 刪除分支](../removing-branch-from-your-repository.md)
 這份文件教你如何從 repository 刪除分支。
 > 在做這些步驟前確定你的 pull request 是被合併的
 
-### [ 保持你的分叉與 repository 同步 ](../keeping-your-fork-synced-with-this-repository.md)
+### [保持你的分叉與 repository 同步](../keeping-your-fork-synced-with-this-repository.md)
 這份文件提供保持分叉與原始 repository 同步的資料。這件事情是很重要的，因為有其他人會對 project 做出貢獻。
 > 如果你的分叉沒有對原始 repository 做改變，根據這些步驟做操作。
 
-### [ 回復 commit ](../reverting-a-commit.md)
+### [回復 commit](../reverting-a-commit.md)
 這份文件提供如何對遠端 repository 回復 commit。這項操作適用在你需要回復 commit，但你已經 push 到 Github。
 > 如果你想要回復 commit，根據這些步驟操作。
 
-### [ 修訂 commit](../amending-a-commit.md)
+### [修訂 commit](../amending-a-commit.md)
 這份文件教你如何在修訂在遠端的 commit。
 > 在你需要調整 commit 的時候使用這個。
 
-### [ 回復本地的 commit ](../undoing-a-commit.md)
+### [回復本地的 commit](../undoing-a-commit.md)
 這份文件教你如何回復本地的 commit。在你覺得你搞砸了本地的 repository，並且希望重置你的 repository時，照著做就對了。
 > 如果你需要回復/重置 commit 時，跟著做吧。
 
-### [ 解決合併時的衝突 ](../resolving-merge-conflicts.md)
+### [解決合併時的衝突](../resolving-merge-conflicts.md)
 這份文件教你解決合併時的衝突。
 > 跟著這些步驟來解決煩人的衝突。
 
@@ -30,17 +30,17 @@
 這份文件教你從本地 repository 中刪除檔案。
 > 跟著這些步驟學習如何從之前的 commit 中刪除檔案。
 
-### [ 移動 commit 到另一個分支 ](../moving-a-commit-to-a-different-branch.md)
+### [移動 commit 到另一個分支](../moving-a-commit-to-a-different-branch.md)
 這份文件教你如何移動 commit 到另一個分支。
 > 跟著步驟移動 commit 到另一個分支。
 
-### [ 配置 git ](../configuring-git.md)
+### [配置 git](../configuring-git.md)
 這份文件教你設定 git 的使用者資料與其他選項。
 > 閱讀這份文件讓你對 git 配置更有掌握。
 
 ### [好用的連結](../Useful-links-for-further-learning.md)
 這份文件包含許多好用的部落格文章、網站、提示和小技巧，了解這些讓我們可以更容易上手。這一頁應該當做好用連結的索引，讓開源的新手還有想認識開源的人可以了解更多。
 
-### [ 擠壓 commits ](../squashing-commits.md)
+### [擠壓 commits](../squashing-commits.md)
 這份文件教你如何藉由互動式 rebase 擠壓 commits。
 > 如果你想要發出一個 PR，但檢閱者要求你將一部份 commits 擠壓成一個 commits 藉由互動式 rebase。

--- a/additional-material/translations/amending-a-commit.ko.md
+++ b/additional-material/translations/amending-a-commit.ko.md
@@ -4,8 +4,8 @@
 
 ### Github에 이미 푸시한 후에 최근 커밋 메시지 변경하기
 파일을 열지 않고 수행할 경우:
-* 다음을 타이핑합니다. ```git commit --amend -m "followed by your new commit message"```
-* 변경사항을 저장소에 커밋하려면 다음을 실행합니다. ```git push origin <branch-name>```
+*   다음을 타이핑합니다. ```git commit --amend -m "followed by your new commit message"```
+*   변경사항을 저장소에 커밋하려면 다음을 실행합니다. ```git push origin <branch-name>```
 
 참고: 단지 ```git commit --amend``` 이것만 입력한다면, 텍스트 편집기가 커밋 메시지를 입력하라고 할 것입니다. ``-m`` 플래그를 추가하면 이것을 막을 수 있습니다.
 
@@ -32,8 +32,8 @@ b0ca8f added single word to botfile
 이 방법은 사소한 변화이기 때문에 더 나을수도 있습니다.
 
 이를 위해 다음을 수행하십시오:
-* 파일을 수정하십시오. 이 경우, 이전에 빠뜨린 단어를 포함하여 봇 파일을 수정합니다.
-* 그 다음, ```git add <filename>``` 을 실행하여 파일을 스테이징 영역으로 추가합니다.
+*   파일을 수정하십시오. 이 경우, 이전에 빠뜨린 단어를 포함하여 봇 파일을 수정합니다.
+*   그 다음, ```git add <filename>``` 을 실행하여 파일을 스테이징 영역으로 추가합니다.
 
 보통 파일을 스테이징 영역에 추가하고 나면, 다음으로 우리가 해야할 일은 git commit -m "our commit message" 입니다.
 그러나 여기서 우리가 원하는 것은 이전 커밋을 수정하는 것이므로, 다음을 실행합니다:
@@ -44,4 +44,3 @@ b0ca8f added single word to botfile
 * ```git push origin <branch-name``` 으로 변경사항을 푸시하십시오.
 
 이렇게 하면 두 변경사항이 단일 커밋이 됩니다.
-

--- a/additional-material/translations/moving-a-commit-to-a-different-branch.ko.md
+++ b/additional-material/translations/moving-a-commit-to-a-different-branch.ko.md
@@ -11,14 +11,14 @@ How can you change that? This is what this tutorial covers.
 ```git reset HEAD~ --soft``` - 마지막 커밋을 되돌립니다. 물론 수정한 내용은 그대로 남아있습니다.  
 ```git stash``` - 현재까지 수정한 모든 작업내용들의 상태를 저장합니다.  
 
-```git checkout name-of-the-correct-branch``` - 실제 반영하고자하는 브랜치를 체크아웃합니다.    
+```git checkout name-of-the-correct-branch``` - 실제 반영하고자하는 브랜치를 체크아웃합니다.
 ```git stash pop``` - 마지막으로 저장한(stash) 변경내역들을 현재 브랜치에 반영하고 저장한 내역에서 삭제합니다.  
 ```git add .``` - 또는 커밋에 반영할 변경내역들을 개별적으로 추가합니다.  
 ```git commit -m "your message here"``` - 저장하고 변경내역을 커밋합니다.  
 
 자 이제 변경사항이 올바른 브랜치에 반영되었습니다.
 
-### 가장 최근 커밋들을 신규 브랜치를 생성하여 이동시키기 
+### 가장 최근 커밋들을 신규 브랜치를 생성하여 이동시키기
 
 사용예:  
 ```git branch newbranch``` -  신규 브랜치를 생성하고 모든 커밋들을 저장합니다.  

--- a/additional-material/translations/removing-branch-from-your-repository.ko.md
+++ b/additional-material/translations/removing-branch-from-your-repository.ko.md
@@ -27,4 +27,4 @@ git push origin --delete <add-your-name>
 자, 여러분은 이제 자신의 브래치를 정리하는 법을 배웠습니다.
 시간이 지나면 많은 커밋이 저장소에 추가됩니다. 그리고 로컬 머신과 GitHub 포크의 마스터 브랜치는 최신 버전이 아닙니다. 따라서 저장소를 내 것과 동기화 된 상태로 유지하려면 아래 단계를 따르십시오.
 
-#### [ 여러분이 포크한 저장소와 싱크상태 유지하기 ](keeping-your-fork-synced-with-this-repository.ko.md)
+#### [여러분이 포크한 저장소와 싱크상태 유지하기](keeping-your-fork-synced-with-this-repository.ko.md)

--- a/additional-material/translations/reverting-a-commit.ko.md
+++ b/additional-material/translations/reverting-a-commit.ko.md
@@ -18,19 +18,18 @@ For example, here is what I get when I run ```git log --oneline ``` on this repo
 c1b9fc1 Merge branch 'master' into tutorials
 77eaafd added tutorial for reverting a commit
 ```
- 
+
 따라서 ```git log --oneline``` 을 사용하면 SHA의 처음 7개의 문자와 함께 저장소에서 작성한 모든 커밋 목록을 가져올 수 있습니다.
 
 이제 "added spacing in title"에 대한 커밋을 취소하고 싶다고 가정하고, 다음 단계를 수행하겠습니다.
 
-* 커밋의 SHA를 복사합니다. 여기서는 ```389004d``` 입니다.
-* 그리고 나서 ```git revert 389004d``` 명령을 싱행합니다.
+*   커밋의 SHA를 복사합니다. 여기서는 ```389004d``` 입니다.
+*   그리고 나서 ```git revert 389004d``` 명령을 싱행합니다.
 
 이렇게 하면 텍스트 편집기가 열리고 커밋 메시지를 편집하라는 메시지가 표시됩니다. 커밋 메시지를 `Revert` 라는 단어로 시작하는 기본 git 메시지로 남겨두거나 원하는대로 메시지를 작성할 수도 있습니다.
 
-* 다음으로, 텍스트 편집기를 저장하고 닫습니다.
-* 커맨드 라인으로 돌아갑니다.
-* ```git push origin <branch-name>``` 을 실행하여 되돌린 변경사항을 Github에 푸시하십시오.
+*   다음으로, 텍스트 편집기를 저장하고 닫습니다.
+*   커맨드 라인으로 돌아갑니다.
+*   ```git push origin <branch-name>``` 을 실행하여 되돌린 변경사항을 Github에 푸시하십시오.
 
 그리고 바로 변경사항이 원상태로 돌아갈 것입니다. 이 경우에 저장소가 ```c1b9fc1``` 의 상태로 되돌아갑니다.
-


### PR DESCRIPTION
I went through the files in the translations folder and cleared out most of the lint warnings. Might still be a few to fix, but hard when language characters are not know to me :)