### PR TITLE
Change tags and search terms to lowercase

### DIFF
--- a/app/src/components/ProjectList/CardsContainer.jsx
+++ b/app/src/components/ProjectList/CardsContainer.jsx
@@ -17,7 +17,7 @@ export default class CardsContainer extends React.Component {
     for (let i = 0; i < projectList.length; i++) {
       if (projectList[i].tags) {
         projectList[i].tags.forEach(tag => {
-          this.setTags.add(tag)
+          this.setTags.add(tag.toLowerCase())
         })
       }
     }
@@ -36,7 +36,8 @@ export default class CardsContainer extends React.Component {
     value.map(v => { valueList.push(v.value) });
     projectList.map(project => {
       if (!project.tags) return;
-      if (valueList.every(v => project.tags.includes(v))) {
+      let lowerCaseTags = project.tags.map(v => v.toLowerCase())
+      if (valueList.every(v => lowerCaseTags.includes(v))) {
         updatedList.push(project);
       }
     })
@@ -52,7 +53,7 @@ export default class CardsContainer extends React.Component {
           options={this.filterOptions}
           multi={true}
         />
-        <section id='project-list' className='Container-layout'> 
+        <section id='project-list' className='Container-layout'>
           { this.state.filterList.map((item, key) => {
             return (
               <Card


### PR DESCRIPTION
Addresses #2562

**Fix**
Change the tags to be displayed to lowercase, and the search term to be lowercase. In the way, all comparisons are done in lower case. User can type the search term in whichever case they want(this is handled by react-select), i.e. `Javascript`, `JavaScript`, `JAVASCRIPT`, and the dropdown menu will give user only one answer. So now users do not have to try different permutations of the same word in different cases.

Img 1: 
![image](https://user-images.githubusercontent.com/26651556/35769499-d2ce5e58-0946-11e8-834c-a691de53aa5a.png)
