### PR TITLE
handleFilterListUpdate now performs case insensitive equals for tags

### DIFF
--- a/app/src/components/ProjectList/CardsContainer.jsx
+++ b/app/src/components/ProjectList/CardsContainer.jsx
@@ -36,7 +36,7 @@ export default class CardsContainer extends React.Component {
     value.map(v => { valueList.push(v.value) });
     projectList.map(project => {
       if (!project.tags) return;
-      if (valueList.every(v => project.tags.find(tag => v.toLowerCase() === tag.toLocaleLowerCase()))) {
+      if (valueList.every(v => project.tags.find(tag => v.toLowerCase() === tag.toLowerCase()))) {
         updatedList.push(project);
       }
     })

--- a/app/src/components/ProjectList/CardsContainer.jsx
+++ b/app/src/components/ProjectList/CardsContainer.jsx
@@ -36,7 +36,7 @@ export default class CardsContainer extends React.Component {
     value.map(v => { valueList.push(v.value) });
     projectList.map(project => {
       if (!project.tags) return;
-      if (valueList.every(v => project.tags.includes(v))) {
+      if (valueList.every(v => project.tags.find(tag => v.toLowerCase() === tag.toLocaleLowerCase()))) {
         updatedList.push(project);
       }
     })


### PR DESCRIPTION
Addresses #2562

Fix
Used find with a callback which performs case insensitive equals to check if project contains tag selected by user.