### PR TITLE
New Salesforce IGA policy change request

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -3388,3 +3388,4 @@
 - [Aditya Khadse](https://github.com/akk5597)
 - [TM Repo](https://github.com/tmrepo)
 - [Supreet Singh](https://github.com/supreetsingh247)
+- [Idan Raman](https://github.com/Idanraman)


### PR DESCRIPTION
Our sales staff currently don't have access to customers files which they don't own directly, as par the security policy that was defined. This restriction slows us down and hinders our productivity
We would like everyone to have access to customers files from their own region