### PR TITLE
Added Alexander Mandt to Contributors List

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -82,6 +82,7 @@
 - [csy0296]
 - [Elizabeth Onder](https://github.com/eonder)
 - [Mike Guilmette](https://github.com/mg0678)
+- [Alexander Mandt](https://github.com/alexmandt)
 - [Boonpraserd Treerayapiwat](https://github.com/boonpraserd)
 - [Christian Salinas](https://github.com/CTSalinas)
 - [Aaron Klapatch](https://github.com/aklapatch)


### PR DESCRIPTION
Alexander Mandt has been added to the Contributors List (Contributors.md)

Signed-off-by: Alexander Mandt <alexander.mandt@outlook.at>