### PR TITLE
Fix antonio suarez link in Contributors list

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -1679,7 +1679,7 @@ modified by bin-w
 - [Gabriel Dekoladenu](https://github.com/gabedeko)
 - [Ramon Reyes](https://github.com/reyesjunk)
 - [Jesus Antonio Zu?iga Arce](https://github.com/jzunigarce)
-- [Antonio Suarez] (https://github.com/GrupoKino)
+- [Antonio Suarez](https://github.com/GrupoKino)
 - [Alexander Swerdlow](https://github.com/aswerdlow935)
 - [Gabriel Araujo](https://github.com/gabrielaraujof)
 - [Jeff Thompson](https://github.com/jello7654)


### PR DESCRIPTION
an extra space after the link didn't show it correctly, this pull is to correct that, i created an issue that could be close #6752 