### PR TITLE
Improve the instructions on Clone the repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,14 +29,14 @@ This will create a copy of this repository in your account.
 
 <img align="right" width="300" src="assets/clone.png" alt="clone this repository" />
 
-Now clone this repo to your machine. Go to your GitHub account, click on the clone button and then click the *copy to clipboard* icon.
+Now clone the forked repo to your machine. Go to your GitHub account, open the forked repo, click on the clone button and then click the *copy to clipboard* icon.
 
 Open a terminal and run the following git command:
 
 ```
 git clone "url you just copied"
 ```
-where "url you just copied" (without the quote marks) is the url to this repository(your fork of this project). See the previous steps to obtain the url.
+where "url you just copied" (without the quote marks) is the url to this repository (your fork of this project). See the previous steps to obtain the url.
 
 <img align="right" width="300" src="assets/copy-to-clipboard.png" alt="copy URL to clipboard" />
 


### PR DESCRIPTION
Some users might mistakenly clone the original repo instead of the forked repo, because the first line of instructions of 'Clone the repository' section does not explicitly says the user should clone his/her forked repo.