### PR TITLE
Add Michael Lore to Contributors list

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -7112,4 +7112,5 @@ Kashish Khullar - :P
 - [HarryPark](https://github.com/phg98)
 - [Brenda-Fitz](https://github.com/brenda-fitz)
 - [James Zhong](https://github.com/thebitspud)
+- [Michael Lore](https://github.com/michaellore)
 - [Chrissy Gonzalez](https://github.com/chrissygonzalez)


### PR DESCRIPTION
Add Michael Lore to the contributors list for Hacktoberfest 2018.