### PR TITLE
README.de.md is written in "Deutsch"

### DIFF
--- a/translations/Translations.md
+++ b/translations/Translations.md
@@ -18,7 +18,7 @@
 | 🇮🇷 | [Persian_Finglish](README.fa.en.md) |
 | 🇱🇹 | [Lietuvių kalba](README.lt.md) |
 | 🇰🇷 🇰🇵 | [한국어](README.ko.md) |
-| 🇩🇪  | [Plattdüütsch](README.de.md) |
+| 🇩🇪  | [Deutsch](README.de.md) |
 | 🇨🇳 🇹🇼 | [中文(Simplified)](README.chs.md), [中文(Traditional)](README.cht.md) |
 | 🇬🇷 | [ελληνικά](README.gr.md) |
 | العربية | [العربية](README.ar.md) |


### PR DESCRIPTION
I think its named "Plattdüütsch" as a joke, but this is very misleading because the README.de.md is written in german/"deutsch" and not in "plattdeutsch".
"Plattdeutsch" is a special dialect.

