### PR TITLE
"added a missing link to a contributor's(Dillon Sykes) profile"

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -122,7 +122,7 @@
 - [Anamol Saxena](https://github.com/anamol-saxena)
 - [Jonathan Tang](https://github.com/jTanG0506)
 - [Mamta Pal](https://github.com/palmamta)
-- [Dillon Sykes]
+- [Dillon Sykes](https://github.com/DillonSykes)
 - [Akash Giri](https://github.com/akashgiricse)
 - [Alejandra Gonzalez](https://github.com/alejandra-gonzalez)
 - [Hassan Murtaza](https://github.com/MrHassanMurtaza)


### PR DESCRIPTION
![sykes](https://user-images.githubusercontent.com/26931277/46811894-7f202880-cd28-11e8-988d-82411dfbe120.PNG)
![sykes2](https://user-images.githubusercontent.com/26931277/46811901-83e4dc80-cd28-11e8-9a52-0fd3a8ebcb19.PNG)
The contributor Dillon Sykes did not add a link to his profile so i tracked down his profile and added the link to it.
Pictures attached are proof of the name-link connection and changes made.