### PR TITLE
Fix contributors.md heading

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -1,4 +1,4 @@
-﻿ontributors
+﻿# Contributors
 - [Neeraj Dwivedi](https://github.com/neerajd007)
 - [Erik T](https://github.com/Etomer)
 - [Jowensky Neard] (https://github.com/Jowensky)


### PR DESCRIPTION
Previous commit broke the heading in contributors.md. This corrects the issue.