### PR TITLE
Fixed broken image source and added Sudipto Ghosh to Contributors.md

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -1,6 +1,6 @@
 ﻿# Contributors
 
--[burak136] (https://github.com/burak136)
+- [burak136] (https://github.com/burak136)
 - [fsidiqs] (https://github.com/fsidiqs)
 - [baclona] (https://github.com/gb853940223)
 - [Ruben Seveelaventhan] (https://github.com/ruben00001)
@@ -13962,3 +13962,4 @@ Tyler Strang
 - [Ananthalakshmi Sankar] (https://github.com/anu294)
 - [Fabian Mesias] (https://github.com/ifmr24)
 - [Ross Wilkinson] (https://github.com/rgwilkin)
+- [Sudipto Ghosh](https://github.com/sudiptog81)

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Now let's get you started with contributing to other projects. We've compiled a 
 
 ## Tutorials Using Other Tools
 
-|<a href="github-desktop-tutorial.md"><img alt="GitHub Desktop" src="https://desktop.github.com/images/desktop-icon.svg" width="100"></a>|<a href="github-windows-vs2017-tutorial.md"><img alt="Visual Studio 2017" src="https://www.visualstudio.com/wp-content/uploads/2017/11/microsoft-visual-studio.svg" width="100"></a>|<a href="gitkraken-tutorial.md"><img alt="GitKraken" src="/assets/gk-icon.png" width="100"></a>|<a href="github-windows-vs-code-tutorial.md"><img alt="VS Code" src="https://upload.wikimedia.org/wikipedia/commons/2/2d/Visual_Studio_Code_1.18_icon.svg" width=100></a>|
+|<a href="github-desktop-tutorial.md"><img alt="GitHub Desktop" src="https://desktop.github.com/images/desktop-icon.svg" width="100"></a>|<a href="github-windows-vs2017-tutorial.md"><img alt="Visual Studio 2017" src="https://upload.wikimedia.org/wikipedia/commons/thumb/c/cd/Visual_Studio_2017_Logo.svg/800px-Visual_Studio_2017_Logo.svg.png" width="95px"></a>|<a href="gitkraken-tutorial.md"><img alt="GitKraken" src="./assets/gk-icon.png" width="100"></a>|<a href="github-windows-vs-code-tutorial.md"><img alt="VS Code" src="https://upload.wikimedia.org/wikipedia/commons/2/2d/Visual_Studio_Code_1.18_icon.svg" width=100></a>|
 |---|---|---|---|
 |[GitHub Desktop](github-desktop-tutorial.md)|[Visual Studio 2017](github-windows-vs2017-tutorial.md)|[GitKraken](gitkraken-tutorial.md)|[Visual Studio Code](github-windows-vs-code-tutorial.md)|
 


### PR DESCRIPTION
Fixes:
- Icon for Visual Studio 2017 changed to [Wikimedia icon](https://upload.wikimedia.org/wikipedia/commons/thumb/c/cd/Visual_Studio_2017_Logo.svg/800px-Visual_Studio_2017_Logo.svg.png) as it does not exist anymore at the [link currently used](https://www.visualstudio.com/wp-content/uploads/2017/11/microsoft-visual-studio.svg) in **README.md**
- Added Sudipto Ghosh to the list of contributors in **Contributors.md**
- Added whitespace to the entry by @burak136 which did not follow valid list item markup (invalid Markdown)