### PR TITLE
Fix broken link

### DIFF
--- a/additional-material/translations/additional-material.id.md
+++ b/additional-material/translations/additional-material.id.md
@@ -2,45 +2,45 @@
 
 Kami berasumsi anda sudah menyelesaikan tutorial dasar sebelum datang ke sini. Informasi tambahan ini akan memberikan beberapa informasi mengenai teknik Git yang lebih tinggi.
 
-### [Hapus cabang dari repositori anda](removing-branch-from-your-repository.md)
+### [Hapus cabang dari repositori anda](../git_workflow_scenarios/removing-branch-from-your-repository.md)
 Dokumen ini memberikan informasi mengenai bagaimana menghapus sebuah cabang dari repositori anda.
 > Lakukan langkah ini setelah pull request anda digabungkan (merge).
 
-### [Agar fork anda tetap sinkron dengan repositori](keeping-your-fork-synced-with-this-repository.md)
+### [Agar fork anda tetap sinkron dengan repositori](../git_workflow_scenarios/keeping-your-fork-synced-with-this-repository.md)
 Dokumen ini memberikan informasi mengenai bagaimana agar repositori yang kita fork tetap uptodate dengan repositori dasar. Hal ini penting, karena bisa jadi anda dan banyak kontributor lain berkontribusi dalam proyek tersebut.
 > Ikuti langkah-langkahnya agar fork anda tidak punya banyak perubahan dengan repositori induk.
 
-### [Membatalkan commit](reverting-a-commit.md)
+### [Membatalkan commit](../git_workflow_scenarios/reverting-a-commit.md)
 Dokumen ini memberikan informasi bagaimana caranya membatalkan commit di repositori remote. Langkah ini perlu jika sewaktu-waktu anda harus membatalkan sebuah commit yang telanjur sudah didorong ke GitHub.
 > Ikuti langkah-langkahnya untuk membatalkan sebuah commit.
 
-### [Mengubah sebuah commit](amending-a-commit.md)
+### [Mengubah sebuah commit](../git_workflow_scenarios/amending-a-commit.md)
 Dokumen ini memberikan informasi mengenai cara mengubah sebuah commit di repositori remote.
 > Gunakan ini ketika kamu harus mengubah commit yang sudah dibuat.
 
-### [Membatalkan commit lokal](undoing-a-commit.md)
+### [Membatalkan commit lokal](../git_workflow_scenarios/undoing-a-commit.md)
 Dokumen ini memberikan informasi mengenai cara membatalkan sebuah commit di repositori lokal anda. Hal ini diperlukan ketika anda berpikir sudah merusak repositori lokal dan ingin me-reset repositori tersebut.
 > Lakukan cara ini jika ingin membatalkan/reset commit di lokal.
 
-### [Mengatasi Merge Conflicts](resolving-merge-conflicts.md)
+### [Mengatasi Merge Conflicts](../git_workflow_scenarios/resolving-merge-conflicts.md)
 Dokumen ini memberikan informasi mengenai cara mengatasi saat terjadi konflik ketika melakukan merge.
 > Lakukan langkah tersebut untuk mengatasi konflik merge yang mengganggu.
 
-### [Menghapus sebuah berkas](removing-a-file.md)
+### [Menghapus sebuah berkas](../git_workflow_scenarios/removing-a-file.md)
 Dokumen ini memberikan informasi mengenai cara menghapus sebuah berkas dari repositori lokal.
 > Ikuti langkah tersebut untuk mempelajari bagaimana menghapus sebuah berkas sebelum di-commit.
 
-### [Memindahkan Commit ke Cabang berbeda](moving-a-commit-to-a-different-branch.md)
+### [Memindahkan Commit ke Cabang berbeda](../git_workflow_scenarios/moving-a-commit-to-a-different-branch.md)
 Dokumen ini memberikan informasi mengenai cara memindahkan sebuah commit ke cabang lain.
 > Ikuti langkah tersebut untuk memindahkan sebuah commit ke cabang lain.
 
-### [Mengonfigurasi git](configuring-git.md)
+### [Mengonfigurasi git](../git_workflow_scenarios/configuring-git.md)
 Dokumen ini memberikan informasi mengenai cara mengonfigurasi detil pengguna dan opsi lain di git.
 > Gunakan langkah ini agar konfigurasi git anda menjadi lebih baik.
 
-### [Tautan bermanfaat](Useful-links-for-further-learning.md)
+### [Tautan bermanfaat](../git_workflow_scenarios/Useful-links-for-further-learning.md)
 Dokumen ini didedikasikan untuk semua pos blog, laman yang sangat membantu, situs tip dan trik yang akan membuat hidup kita lebih mudah. Tautan tersebut tidak hanya untuk pemula, namun juga bagi yang sudah mahir. Halaman ini akan menjadi indeks untuk semua tautan yang bermanfaat yang mungkin saja bisa membantu siapapun yang baru terjun di dunia open-source atau siapapun yang ingin belajar lebih lanjut.
 
-### [Menyatukan banyak Commit](squashing-commits.md)
+### [Menyatukan banyak Commit](../git_workflow_scenarios/squashing-commits.md)
 Dokumen ini menyediakan informasi mengenai bagaimana menyederhanakan banyak commit dengan rebase interaktif.
 > Gunakan ini jika anda mau membuka sebuah PR dalam proyek open source dan periview meminta kamu untuk menyatukan setiap commit menjadi satu, dengan pesan commit yang informatif.


### PR DESCRIPTION
Fix broken link in Indonesian translation for `additional-material`

for example:
From `(amending-a-commit.md)` to `(../git_workflow_scenarios/amending-a-commit.md)`