### PR TITLE
Add to Contributors list + small spacing changes

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -1,7 +1,8 @@
- Contributors
--[Gregory El Bajoury] (https://github.com/Injechta)
--[Rob Harman]
--[Alandouglas Godinho Mendes](https://github.com/AlandouglasMendes/)
+﻿ Contributors
+- [Greg Williams](https://github.com/starskee)
+- [Gregory El Bajoury](https://github.com/Injechta)
+- [Rob Harman]
+- [Alandouglas Godinho Mendes](https://github.com/AlandouglasMendes/)
 - [Aryen Hemvatan] (https://github.com/TheJackalTR)
 - [Piyush Aggarwal] (https://github.com/piyush5807)
 - [tannedthighs]


### PR DESCRIPTION
I also changed some spacing for contributor names near mine to properly show their names on the GitHub page as a hyperlink instead of showing the link to their GitHub profile.