### PR TITLE
Removed link from my name

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -17007,7 +17007,7 @@ macdara-dev
 - [pittyi2nd](https://github.com/pittyi2nd)
 - [Hoang Vu](https://github.com/hoangvq288)
 - [egordorichev](https://github.com/egordorichev)
-- [Nicholas Dalhaug](https://github.com/nicholasdalhaug)
+- Nicholas Dalhaug
 - [kuraus](https://github.com/kuraus)
 - [Adarsh Dwivedi](https://github.com/adarshd8127)
 - [Abdul Rehman](https://github.com/Abdul-Sen)


### PR DESCRIPTION
I appreciate the project! I did not think it would be used as a database of contact information, which was silly. I therefore want the link from my name to be removed. 