### PR TITLE
fix internal link at README.pt_br.md

### DIFF
--- a/translations/README.pt_br.md
+++ b/translations/README.pt_br.md
@@ -9,7 +9,7 @@
 
 Ler artigos e ver tutoriais pode ajudar, mas o que é melhor do que realmente pôr a mão na massa em um ambiente prático? Este projeto visa guiar e simplificar a forma com que os novatos fazem a sua primeira contribuição. Se quiser fazer a sua primeira contribuição, siga os passos abaixo.
 
-#### *Se você não se sente confortável com linha de comando, [aqui estão alguns tutoriais de ferramentas gráficas.]( #tutoriais-com-outras-ferramentas)*
+#### *Se você não se sente confortável com linha de comando, [aqui estão alguns tutoriais de ferramentas gráficas.]( #Tutoriais-usando-outras-ferramentas)*
 
 
 #### *Ler em [outros idiomas](../translations/Translations.md)* 


### PR DESCRIPTION
Hi, I fixed a broken link at the Brazilian Portuguese translation (README.pt_br.md), the link should point to the **GUIs tools for git**, however, the title and tag name were different, causing the issue. 

@OtacilioN 