### PR TITLE
Adding deecoders as a contributor

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -10,6 +10,7 @@
 - [Vatsal Gupta (vatsuvaksi) (https://github.com/vatsuvaksi)
 - [CHACHA VIDHYAK HAI MERA!!!](https://github.com/vasut02)
 - [UmmuZurak](https://github.com/UmmuZurak)
+- [deecoders](https://github.com/deecoders)
 - [Muhammed Rizal]
 - [YogeshNile](https://github.com/yogeshnile)
 - [Nikolaus Koopmann](https://github.com/PremKolar)


### PR DESCRIPTION
## Description

Start deecoders journey to open source

## Design and Implementation

Adding decoders name in **contributor's list** in github's famous [to get started repo](https://github.com/firstcontributions/first-contributions).

## Testing 
Looking good

## Result
That starts decoders open source joueney