### PR TITLE
 hacktoberfest 2020

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -18,6 +18,8 @@
 - [Jasmine Moua](https://github.com/mouajas)
 - [Gedalia Rabinowitz](https://github.com/GedaliaR)
 - [547y4m](https://github.com/547y4m) 
+- hacktoberfest
+- hacktoberfest2020
 - Motunrayo
 - Morgan
 - [coderAbhii](https://github.com/coderAbhii)
@@ -586,6 +588,7 @@
 - [Chintana Prabhu](https://github.com/chintanaprabhu)
 - [Pedro Gesta](https://github.com/pedrogestajr)
 - [Danny Cheun](https://github.com/dcheun)
+- [ahmadarifinrizkiakbar](https://github.com/ahmadarifinrizkiakbar)
 - sejal
 - [Israel](https://github.com/israeltn)
 - [Amit Yadav]


### PR DESCRIPTION
I think we shouldn't add hacktoberfest topic for this repository.

My main reasoning is that this repo doesn't comply with the rules Hacktoberfest has set for the event.
You can find it in https://hacktoberfest.digitalocean.com/details#spam

Bad repositories will be excluded. In the past, we've seen many repositories that encourage participants to make simple pull requests – such as adding their name to a file – to quickly gain a pull request toward completing Hacktoberfest. While this may be a learning tool for new contributors, it goes against one of our core values for Hacktoberfest. The quality of pull requests is paramount; quantity comes second. These repositories do not encourage quality contributions and provide an unfair advantage in completing the Hacktoberfest challenge. We've implemented a system to block these repositories, and any pull requests submitted to such repositories will not be counted.