### PR TITLE
added fetch and merge remote changes at same time command 

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -13,6 +13,7 @@
 - [Ty Richardson](https://github.com/tyrichardson)
 - [Martin Arroyo](https://github.com/martinarroyo777)
 - [kris tel](https://github.com/panamtown04)
+- [Koshima Goyal](https://github.com/koshimagoyal)
 - [Su Wei](https://github.com/akasuv)
   [Harsh Thumar]
 - [Queena](https://github.com/canikillyoulater)

--- a/additional-material/git_workflow_scenarios/keeping-your-fork-synced-with-this-repository.md
+++ b/additional-material/git_workflow_scenarios/keeping-your-fork-synced-with-this-repository.md
@@ -37,4 +37,9 @@ git push origin master
 ```
 Notice here you're pushing to the remote named `origin`.
 
+If you want to fetch and merge the latest changes of my fork (`upstream` remote) to your local branch at same time then you can directly go for:
+```
+git pull upstream master
+```
+
 So by now or at this point, all your repositories are up-to-date. Well done! You should do this, everytime your GitHub repo tells you that you are a few commits behind.


### PR DESCRIPTION
added fetch and merge remote changes at same time command in keeping-your-fork-synced-with-this-repository.md document - git pull upstream master

- this will allow developers to fetch and merge remote changes to their local branch
- developers can run one command rather than running two different commands