### PR TITLE
Update README.pt_br.md to include missing sentence

### DIFF
--- a/translations/README.pt_br.md
+++ b/translations/README.pt_br.md
@@ -62,7 +62,7 @@ Obs.: O nome do Branch não precisa ter a sigla "add", mas nesse caso é recomen
 
 ## Efetue as alterações necessárias e faça um Commit
 
-Agora abra o arquivo `Contributors.md` em seu editor de código, adicione o seu nome a ele e salve o arquivo. 
+Agora abra o arquivo `Contributors.md` em seu editor de código e adicione o seu nome. Não coloque seu nome no início ou no final do arquivo. Coloque-o em qualquer lugar no meio do documento e salve o arquivo.
 
 <img align="right" width="450" src="https://firstcontributions.github.io/assets/Readme/git-status.png" alt="git status" />
 
@@ -108,10 +108,8 @@ Agora você pode colaborar com outros projetos. Nós compilamos uma lista de pro
 
 ### [ Material adicional ](../additional-material/translations/additional-material.pt_br.md)
 
-
 ## Tutoriais usando outras ferramentas
 
 |<a href="../github-desktop-tutorial.md"><img alt="GitHub Desktop" src="https://desktop.github.com/images/desktop-icon.svg" width="100"></a>|<a href="../github-windows-vs2017-tutorial.md"><img alt="Visual Studio 2017" src="https://upload.wikimedia.org/wikipedia/commons/2/2d/Visual_Studio_Code_1.18_icon.svg" width="100"></a>|<a href="../gitkraken-tutorial.md"><img alt="GitKraken" src="https://firstcontributions.github.io/assets/Readme/gk-icon.png" width="100"></a>| <a href="github-windows-intellij-tutorial.md"><img alt="IntelliJ IDEA" src="https://upload.wikimedia.org/wikipedia/commons/d/d5/IntelliJ_IDEA_Logo.svg" width=100></a> |
 |---|---|---|---|
 |[GitHub Desktop](../github-desktop-tutorial.md)|[Visual Studio 2017](../github-windows-vs2017-tutorial.md)|[GitKraken](../gitkraken-tutorial.md)|[IntelliJ IDEA](../gui-tool-tutorials/translations/github-windows-intellij-tutorial.pt_br.md)         |
-


### PR DESCRIPTION
On line 133 of the original README.md in English, it reads: Now open `Contributors.md` file in a text editor, add your name to it. Don't add it at the beginning or end of the file. Put it anywhere in between. Now, save the file.

In the Brazilian Portuguese translation, the sentences _Don't add it at the beginning or end of the file. Put it anywhere in between_ are missing. 

This information seems important, so I thought I should add it.

Thank you!