### PR TITLE
Changed streffurth for the link to appear correct.

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -10132,7 +10132,7 @@
 
 sam_namiranian
 
-- [Sebastian Treffurth] (https://github.com/streffurth)
+- [Sebastian Treffurth](https://github.com/streffurth)
 - [Ntomb L. Nelson J.](https://github.com/Nelson-J)
 - [Guilherme Camargo](https://github.com/camargoguilherme)
 - rsey


### PR DESCRIPTION
Removed the space between the name and the profile link, so that the link to the profile appears on the name.