### PR TITLE
Error in git push session in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ replacing `<your-name>` with your name.
 Push your changes using the command `git push`:
 
 ```
-git push origin <add-your-branch-name>
+git push origin -u <add-your-branch-name>
 ```
 
 replacing `<add-your-branch-name>` with the name of the branch you created earlier.


### PR DESCRIPTION
there is a small error in the readme in the area where it says the command to push to git. Iam on pop os it works only in this way in my system, please take a look and leave a feedback 

![image](https://user-images.githubusercontent.com/73947101/120110128-f3ce5c80-c189-11eb-8332-8f7184b6a77f.png)
