### PR TITLE
Add additional-material translated into Japanese :jp:

### DIFF
--- a/additional-material/translations/additional-material.ja.md
+++ b/additional-material/translations/additional-material.ja.md
@@ -1,0 +1,49 @@
+# Additional information
+
+We assume that you have already finished with the basic tutorial before coming here. This document will give you some additional information about advanced Git techniques.
+
+### [Amending a commit](amending-a-commit.md)
+This document provides information about how to amend a commit on the remote repository.
+> Use this when you need to adjust a commit you made.
+
+### [Configuring git](configuring-git.md)
+This document provides information about how to configure user details and other options in git.
+> Use this to better control your git configurations.
+
+### [Keeping your fork synced with the repository](keeping-your-fork-synced-with-this-repository.md)
+This document provides information about how to keep your forked repository up-to-date with the base repository. This is important, as hopefully you and many others will contribute to the project.
+> Follow these steps if your fork doesn't have any changes in parent repository.
+
+### [Moving a Commit to a different Branch](moving-a-commit-to-a-different-branch.md)
+This document provides information about how to move a Commit to another Branch.
+> Take these steps to move a commit to another branch.
+
+### [Removing a File](removing-a-file.md)
+This document provides information about how to remove a file from your local repository.
+> Follow these steps to learn how to remove a file prior to a commit
+
+### [Removing a branch from your repository](removing-branch-from-your-repository.md)
+This document provides information about how to delete a branch from your repository.
+> Only do these steps after your pull request get's merged.
+
+### [Resolving Merge Conflicts](resolving-merge-conflicts.md)
+This document provides information about how to resolve merge conflicts.
+> Take these steps to resolve the annoying merge conflicts.
+
+### [Reverting a commit](reverting-a-commit.md)
+This document provides information about how to revert a commit on the remote repository. It will come in handy in case you need to undo a commit that has already been pushed to Github.
+> Take these steps if you want to reverse a commit.
+
+### [Squashing Commits](squashing-commits.md)
+This document provides information about how to squash commits with an interactive rebase.
+> Use this if you want to open a PR in an open source project and the reviewer asks you to squash every commit into one, with an informative commit message.
+
+### [Undo-ing a local commit](undoing-a-commit.md)
+This document provides information about how to undo a commit on your local repository. This is what you need to do when you feel you've messed up your local repository and wish to reset the local repository.
+> Take these steps if you want to undo/reset a local commit.
+
+### [Useful Links](Useful-links-for-further-learning.md)
+This document is dedicated to all the tips and tricks websites, blog posts, and helpful sites that make our lives easier. They are a great reference to serve all of our needs, be it a beginner or an expert. This page should act as an index of all those useful links that would help everybody who is new in the open-source domain or someone who wants to learn more.
+
+### [Creating a .gitignore file](creating-a-gitignore-file.md)
+This document explains what a .gitignore file does, why to use it and how to create a .gitignore file. This file is used in almost all git projects. It helps commit only necessary files to git.

--- a/additional-material/translations/additional-material.ja.md
+++ b/additional-material/translations/additional-material.ja.md
@@ -17,8 +17,8 @@
 > あなたのフォークが親リポジトリに変更を加えていない場合は、リンク先の手順に従ってください。
 
 ### [Moving a Commit to a different Branch](moving-a-commit-to-a-different-branch.md)
-This document provides information about how to move a Commit to another Branch.
-> Take these steps to move a commit to another branch.
+このドキュメントでは、コミットを別のブランチに移動させる方法について説明しています。
+> 手順に沿って、コミットを別ブランチに移動させます。
 
 ### [Removing a File](removing-a-file.md)
 This document provides information about how to remove a file from your local repository.

--- a/additional-material/translations/additional-material.ja.md
+++ b/additional-material/translations/additional-material.ja.md
@@ -51,4 +51,5 @@
 初心者上級者問わず、開発者すべてのニーズに応えてくれる偉大な参考資料です。
 
 ### [Creating a .gitignore file](creating-a-gitignore-file.md)
-This document explains what a .gitignore file does, why to use it and how to create a .gitignore file. This file is used in almost all git projects. It helps commit only necessary files to git.
+このドキュメントでは、.gitignoreファイルの役割、使用する理由、.gitignoreファイルの作成方法について説明します。このファイルは、ほとんどすべてのgitプロジェクトで使用されます。必要なファイルだけをgitにコミットするのに役立ちます。
+

--- a/additional-material/translations/additional-material.ja.md
+++ b/additional-material/translations/additional-material.ja.md
@@ -21,8 +21,8 @@
 > 手順に沿って、コミットを別ブランチに移動させます。
 
 ### [Removing a File](removing-a-file.md)
-This document provides information about how to remove a file from your local repository.
-> Follow these steps to learn how to remove a file prior to a commit
+このドキュメントでは、ローカルリポジトリからファイルを削除する方法について説明しています。
+> コミット前にファイルを削除する方法です。
 
 ### [Removing a branch from your repository](removing-branch-from-your-repository.md)
 This document provides information about how to delete a branch from your repository.

--- a/additional-material/translations/additional-material.ja.md
+++ b/additional-material/translations/additional-material.ja.md
@@ -25,8 +25,8 @@
 > コミット前にファイルを削除する方法です。
 
 ### [Removing a branch from your repository](removing-branch-from-your-repository.md)
-This document provides information about how to delete a branch from your repository.
-> Only do these steps after your pull request get's merged.
+このドキュメントでは、あなたのリポジトリからブランチを削除する方法について説明しています。
+> ブランチの削除は、プルリクエストがマージ(merge)されてからにしてください！
 
 ### [Resolving Merge Conflicts](resolving-merge-conflicts.md)
 This document provides information about how to resolve merge conflicts.

--- a/additional-material/translations/additional-material.ja.md
+++ b/additional-material/translations/additional-material.ja.md
@@ -38,8 +38,8 @@
 > あなたがリポジトリをリバートしたい場合に、この手順に沿ってください。
 
 ### [Squashing Commits](squashing-commits.md)
-This document provides information about how to squash commits with an interactive rebase.
-> Use this if you want to open a PR in an open source project and the reviewer asks you to squash every commit into one, with an informative commit message.
+このドキュメントでは、対話的な(interactive)リベース(rebase)を使って、果実をぎゅっと絞る(squash)ようにコミットをまとめる方法について説明します。
+> オープンソースプロジェクトでプルリクエスト(PR)を公開し、レビュアーからすべてのコミットを1つにまとめてコミットメッセージを表示するよう求められた場合に使用します。
 
 ### [Undo-ing a local commit](undoing-a-commit.md)
 This document provides information about how to undo a commit on your local repository. This is what you need to do when you feel you've messed up your local repository and wish to reset the local repository.

--- a/additional-material/translations/additional-material.ja.md
+++ b/additional-material/translations/additional-material.ja.md
@@ -1,6 +1,6 @@
-# Additional information
+# 追加情報
 
-We assume that you have already finished with the basic tutorial before coming here. This document will give you some additional information about advanced Git techniques.
+ここに来る前に、基本的なチュートリアルをすでに完了していることを前提としています。このドキュメントでは、高度なGitテクニックに関する追加情報を提供します。
 
 ### [Amending a commit](amending-a-commit.md)
 This document provides information about how to amend a commit on the remote repository.

--- a/additional-material/translations/additional-material.ja.md
+++ b/additional-material/translations/additional-material.ja.md
@@ -11,8 +11,10 @@
 > gitの設定をもっとよく制御したい場合に使用します。
 
 ### [Keeping your fork synced with the repository](keeping-your-fork-synced-with-this-repository.md)
-This document provides information about how to keep your forked repository up-to-date with the base repository. This is important, as hopefully you and many others will contribute to the project.
+このドキュメントは、フォーク(fork)したリポジトリを最新の状態に保つ方法を説明します。これはあなたや他の多くの人がプロジェクトに貢献するかもしれないので、重要です！
+(最新の状態に保たないと、あなたのリポジトリに新しい追加が反映されません。)
 > Follow these steps if your fork doesn't have any changes in parent repository.
+> あなたのフォークが親リポジトリに変更を加えていない場合は、リンク先の手順に従ってください。
 
 ### [Moving a Commit to a different Branch](moving-a-commit-to-a-different-branch.md)
 This document provides information about how to move a Commit to another Branch.

--- a/additional-material/translations/additional-material.ja.md
+++ b/additional-material/translations/additional-material.ja.md
@@ -42,8 +42,8 @@
 > オープンソースプロジェクトでプルリクエスト(PR)を公開し、レビュアーからすべてのコミットを1つにまとめてコミットメッセージを表示するよう求められた場合に使用します。
 
 ### [Undo-ing a local commit](undoing-a-commit.md)
-This document provides information about how to undo a commit on your local repository. This is what you need to do when you feel you've messed up your local repository and wish to reset the local repository.
-> Take these steps if you want to undo/reset a local commit.
+このドキュメントはローカルリポジトリのコミットを取り消す方法について説明します。これは、ローカルリポジトリをリセット(reset)したい場合に必要になります。
+> ローカルリポジトリを元に戻す/リセットする
 
 ### [Useful Links](Useful-links-for-further-learning.md)
 This document is dedicated to all the tips and tricks websites, blog posts, and helpful sites that make our lives easier. They are a great reference to serve all of our needs, be it a beginner or an expert. This page should act as an index of all those useful links that would help everybody who is new in the open-source domain or someone who wants to learn more.

--- a/additional-material/translations/additional-material.ja.md
+++ b/additional-material/translations/additional-material.ja.md
@@ -3,8 +3,8 @@
 ここに来る前に、基本的なチュートリアルをすでに完了していることを前提としています。このドキュメントでは、高度なGitテクニックに関する追加情報を提供します。
 
 ### [Amending a commit](amending-a-commit.md)
-This document provides information about how to amend a commit on the remote repository.
-> Use this when you need to adjust a commit you made.
+このドキュメントはリモートリポジトリのコミットを修正（ammend）する方法を提供します。
+> 自分の作成したコミットを調整する必要がある場合に使用します。
 
 ### [Configuring git](configuring-git.md)
 This document provides information about how to configure user details and other options in git.

--- a/additional-material/translations/additional-material.ja.md
+++ b/additional-material/translations/additional-material.ja.md
@@ -46,7 +46,9 @@
 > ローカルリポジトリを元に戻す/リセットする
 
 ### [Useful Links](Useful-links-for-further-learning.md)
-This document is dedicated to all the tips and tricks websites, blog posts, and helpful sites that make our lives easier. They are a great reference to serve all of our needs, be it a beginner or an expert. This page should act as an index of all those useful links that would help everybody who is new in the open-source domain or someone who wants to learn more.
+このドキュメントは、私達のこれからの活動に役立つ便利なTips、Tricks、ブログ、Webアプリの為のページです。
+オープンソースの世界に入ったばかりの人や、もっと学びたいと思っている人に役立つ、有用なリンクのインデックスとして機能します。
+初心者上級者問わず、開発者すべてのニーズに応えてくれる偉大な参考資料です。
 
 ### [Creating a .gitignore file](creating-a-gitignore-file.md)
 This document explains what a .gitignore file does, why to use it and how to create a .gitignore file. This file is used in almost all git projects. It helps commit only necessary files to git.

--- a/additional-material/translations/additional-material.ja.md
+++ b/additional-material/translations/additional-material.ja.md
@@ -29,8 +29,8 @@
 > ブランチの削除は、プルリクエストがマージ(merge)されてからにしてください！
 
 ### [Resolving Merge Conflicts](resolving-merge-conflicts.md)
-This document provides information about how to resolve merge conflicts.
-> Take these steps to resolve the annoying merge conflicts.
+このドキュメントでは、マージコンフリクト(merge confrict)を解消する方法について説明しています。
+> 悩ましいコンフリクトを解消する方法です。
 
 ### [Reverting a commit](reverting-a-commit.md)
 This document provides information about how to revert a commit on the remote repository. It will come in handy in case you need to undo a commit that has already been pushed to Github.

--- a/additional-material/translations/additional-material.ja.md
+++ b/additional-material/translations/additional-material.ja.md
@@ -33,8 +33,9 @@
 > 悩ましいコンフリクトを解消する方法です。
 
 ### [Reverting a commit](reverting-a-commit.md)
-This document provides information about how to revert a commit on the remote repository. It will come in handy in case you need to undo a commit that has already been pushed to Github.
-> Take these steps if you want to reverse a commit.
+このドキュメントはどうやってリモートリポジトリをもとに戻す(revert)かについて説明します。
+これはすでにGithubにプッシュされているコミットをもとに戻す必要がある場合に便利です。
+> あなたがリポジトリをリバートしたい場合に、この手順に沿ってください。
 
 ### [Squashing Commits](squashing-commits.md)
 This document provides information about how to squash commits with an interactive rebase.

--- a/additional-material/translations/additional-material.ja.md
+++ b/additional-material/translations/additional-material.ja.md
@@ -7,8 +7,8 @@
 > 自分の作成したコミットを調整する必要がある場合に使用します。
 
 ### [Configuring git](configuring-git.md)
-This document provides information about how to configure user details and other options in git.
-> Use this to better control your git configurations.
+このドキュメントでは、gitにおけるユーザーの詳細設定(configure)やその他のオプションの設定方法について説明します。
+> gitの設定をもっとよく制御したい場合に使用します。
 
 ### [Keeping your fork synced with the repository](keeping-your-fork-synced-with-this-repository.md)
 This document provides information about how to keep your forked repository up-to-date with the base repository. This is important, as hopefully you and many others will contribute to the project.


### PR DESCRIPTION
Hi! I'm ken-ty . :baby: 
Please review this PR !

### :lady_beetle:  Problem
There is no Japanese translation file for `additional-material.md`.

### :dart: Goal
There is a Japanese translation file for `additional-material.md`, It's named `additional-material.ja.md`.

### :bulb: Possible solutions
Translate `additional-material.md` into Japanese.

### :clipboard: Steps to solve the problem

- [x] Copy  `additional-material/git_workflow_scenarios/additional-material.md`
to `additional-material/translations/additional-material.ja.md`
- [x] Translate `additional-material.ja.md` into Japanese :jp: step by step.

This pull request range of only `additional-material.ja.md`.
For each links in this file,  it is the same page links as before.
It's hopeful to add translation link pages into Japanese :jp: in the future!
