### PR TITLE
Improving grammar

### DIFF
--- a/additional-material/translations/additional-material.pt_br.md
+++ b/additional-material/translations/additional-material.pt_br.md
@@ -24,7 +24,7 @@ Esse documento provê informações sobre como remover um arquivo do seu reposit
 
 ### [Removendo um Branch do seu repositório](../git_workflow_scenarios/removing-branch-from-your-repository.md)
 Esse documento provê informações sobre como deletar um Branch do seu repositório.
-> Apenas siga esses passos após o seu pull request ter sido mesclado.
+> Apenas siga esses passos após o seu pull request ter sido integrado.
 
 ### [Resolvendo conflitos de Merge](../git_workflow_scenarios/resolving-merge-conflicts.md)
 Esse documento provê informações sobre como resolver conflitos de Merge.
@@ -43,4 +43,4 @@ Esse documento provê informações sobre como desfazer um commit no seu reposit
 > Take these steps if you want to undo/reset a local commit.
 
 ### [Links úteis](../git_workflow_scenarios/Useful-links-for-further-learning.md)
-Esse documento é dedicado a todos os blog posts, sites úteis, dicas e truques que fazem a nossa vida mais simples. Seja você um expert ou um iniciante, essa pagina deve servir como um index para todos esses links úteis para ajudar qualquer um que seja novo no mundo de projetos open-source ou alguém que queira prender mais a respeito.
+Esse documento é dedicado a todos os blog posts, sites úteis, dicas e truques que fazem a nossa vida mais simples. Seja você um expert ou um iniciante, essa página deve servir como um index para todos esses links úteis para ajudar qualquer um que seja novo no mundo de projetos open-source ou alguém que queira prender mais a respeito.

--- a/translations/README.pt-pt.md
+++ b/translations/README.pt-pt.md
@@ -7,7 +7,7 @@
 
 É difícil. É sempre difícil fazer algo pela primeira vez. Especialmente quando se está a colaborar, errar não é algo agradável. Mas *open source* (código aberto) trata-se de colaboração e de trabalharmos juntos. Queremos simplificar a forma com que novos colaboradores *open source* aprendem e contribuem pela primeira vez.
 
-Ler artigos e ver tutoriais pode ajudar, mas nada melhor do que realmente "pôr a mão na massa" sem estragar nada. Este projeto visa simplificar a forma com que os novatos fazem a sua primeira contribuição. Lembra-te: quanto mais relaxado(a) estiveres, melhor aprenderás. Se quiseres fazer a tua primeira contribuição, segue os passos abaixo. Nós prometemos, será divertido.
+Ler artigos e ver tutoriais pode ajudar, mas nada melhor do que realmente "pôr a mão na massa" sem estragar nada. Este projecto visa simplificar a forma com que os novatos fazem a sua primeira contribuição. Lembra-te: quanto mais relaxado(a) estiveres, melhor aprenderás. Se quiseres fazer a tua primeira contribuição, segue os passos abaixo. Nós prometemos, será divertido.
 
 Se ainda não tens o git na tua máquina, [instala-o aqui]( https://help.github.com/articles/set-up-git/ ).
 
@@ -38,7 +38,7 @@ onde "este-eh-voce" é o seu usuário do GitHub. Aqui estas a copiar o conteúdo
 
 ## Cria um Branch
 
-Vá para o diretório do repositório no teu computador (caso ainda não estejas lá):
+Vá para o directório do repositório no teu computador (caso ainda não estejas lá):
 ```
 cd first-contributions
 ```
@@ -56,7 +56,7 @@ Obs.: O nome do Branch não precisa de ter a sigla "add", mas neste caso é reco
 
 ## Efetua as alterações necessárias e faz um Commit
 
-Agora abre o ficheiro `Contributors.md` no teu editor de código, adiciona o teu nome nele e guarda o ficheiro. Se fores para o diretório do projeto e executar o comando `git status`, verás que há alterações. Adiciona essas alterações ao Branch que acabaste de criar utilizando o comando `git add`:
+Agora abre o ficheiro `Contributors.md` no teu editor de código, adiciona o teu nome nele e guarda o ficheiro. Se fores para o directório do projecto e executar o comando `git status`, verás que há alterações. Adiciona essas alterações ao Branch que acabaste de criar utilizando o comando `git add`:
 ```
 git add Contributors.md
 ```
@@ -84,7 +84,7 @@ Agora envia um Pull Request.
 
 <img style="float: right;" src="https://firstcontributions.github.io/assets/Readme/submit-pull-request.png" alt="Envia um pull request" />
 
-Logo estarei a incorporar as tuas mudanças no Branch principal (master) deste projeto. Vais receber um e-mail de notificação quando as alterações forem incorporadas.
+Logo estarei a incorporar as tuas mudanças no Branch principal (master) deste projecto. Vais receber um e-mail de notificação quando as alterações forem incorporadas.
 
 ## Para onde ir a partir daqui?
 

--- a/translations/README.pt_br.md
+++ b/translations/README.pt_br.md
@@ -111,7 +111,7 @@ Agora você pode colaborar com outros projetos. Nós compilamos uma lista de pro
 
 ## Tutoriais usando outras ferramentas
 
-|<a href="../github-desktop-tutorial.md"><img alt="GitHub Desktop" src="https://desktop.github.com/images/desktop-icon.svg" width="100"></a>|<a href="../github-windows-vs2017-tutorial.md"><img alt="Visual Studio 2017" src="https://upload.wikimedia.org/wikipedia/commons/2/2d/Visual_Studio_Code_1.18_icon.svg" width="100"></a>|<a href="../gitkraken-tutorial.md"><img alt="GitKraken" src="https://firstcontributions.github.io/assets/Readme/gk-icon.png" width="100"></a>| <a href="github-windows-intellij-tutorial.md"><img alt="IntelliJ IDEA" src="https://upload.wikimedia.org/wikipedia/commons/d/d5/IntelliJ_IDEA_Logo.svg" width=100></a> |
+|<a href="../github-desktop-tutorial.md"><img alt="GitHub Desktop" src="https://desktop.github.com/images/desktop-icon.svg" width="100"></a>|<a href="../github-windows-vs2017-tutorial.md"><img alt="Visual Studio 2017" src="https://upload.wikimedia.org/wikipedia/commons/2/2d/Visual_Studio_Code_1.18_icon.svg" width="100"></a>|<a href="../gitkraken-tutorial.md"><img alt="GitKraken" src="https://firstcontributions.github.io/assets/Readme/gk-icon.png" width="100"></a>| <a href="github-windows-intellij-tutorial.md"><img alt="IntelliJ IDEA" src="https://upload.wikimedia.org/wikipedia/commons/thumb/9/9c/IntelliJ_IDEA_Icon.svg/512px-IntelliJ_IDEA_Icon.svg.png" width=100></a> |
 |---|---|---|---|
 |[GitHub Desktop](../github-desktop-tutorial.md)|[Visual Studio 2017](../github-windows-vs2017-tutorial.md)|[GitKraken](../gitkraken-tutorial.md)|[IntelliJ IDEA](../gui-tool-tutorials/translations/github-windows-intellij-tutorial.pt_br.md)         |
 


### PR DESCRIPTION
# As mudanças foram as seguintes:

1.  ### README.pt-pt.md:

- **`projeto`** para **`projecto`**

- **`diretorio`** para **`directorio`**

Assim sendo, existem dois ficheiros REAME.md um para Português do Portugal e outro para Português do Brasil, para diferenciar. Caso não houvesse uma diferença de sintaxe dos dois países, porquê fariam dois ficheiros README para o português? 😉

@nunofca solicito uma revisão para este ficheiro.

2.  ### README.pt_br.md:

- Concertei o link de carregamento da imagem do ícon do IntelliJ IDEA.

@gabrielsanttana solicito uma revisão para este ficheiro.

3.  ### additional-material.pt_br.md:
- **Linguagem**

**`mesclado`** para **`integrado`**

**mesclar** é uma palavra pouco usada e pouco conhecida no contexto geral da programação em língua portuguesa. O sinônimo mais conhecido e compreensível (especialmente para colaboradores iniciantes do GitHub) é **`integrar`**.

@gabrielsanttana solicito uma revisão para este ficheiro.