### PR TITLE
Fix Prettier Ignore

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -5636,7 +5636,6 @@ Michael Wong
 - [Creberus] (https://github.com/Creberus)
 - [Clément Despiney](https://github.com/cdespiney)
 - [Rahul Singh Karki]
-- <!-- prettier-ignore-end -->
 - [justartover](https://github.com/justartover1)
 - [Gordon Lin](https://github.com/gordonlin-dev)
 - [Alper Gungor](https://github.com/alpergng)
@@ -5761,3 +5760,5 @@ Michael Wong
 - [rorooooooo] (https://github.com/rorooooooo)
 - [asherhe](https://github.com/asherhe)
 - [rorima](https://github.com/rorima)
+
+<!-- prettier-ignore-end -->


### PR DESCRIPTION
Due to the Prettier Ignore code being moved from the end at some point, contributors with Prettier installed can easily make huge numbers of changes to the file without even realising it.

This could be contributing to the huge backlog of pull requests!

- [x] Moved Prettier Ignore code line to the end