### PR TITLE
Add Mason C to Contributors list

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -25,6 +25,7 @@
 - [John Michael Darrin](https://github.com/JohnMichaelD)
 - [Emmanuel Anuoluwa Bamidele](https://github.com/Emmanuel-Bamidele)
 - [Poirei Ngamba Singha K](https://github.com/poirei)
+- Mason C
 - [Kieran Klukas](https://github.com/kcoderhtml)
 - [Karan Agarwal](https://https://github.com/i-m-karanagarwal)
 - [diana](https://github.com/difince)


### PR DESCRIPTION
Maybe add something in the explanation to tell people where the Contributors.md file is.  I had no idea it was going into my User folder, and once finding that out, I decided to create a repository folder in my Git directory to be my default destination for cloned repositories.