### PR TITLE
fix typo 

### DIFF
--- a/translations/README.eg.md
+++ b/translations/README.eg.md
@@ -61,7 +61,7 @@ git clone https://github.com/this-is-you/first-contributions.git
 </div>
 <br>
 
-## <div dir="rtl">  فصل فرع - Create a branch </div>
+## <div dir="rtl">  إنشاء فرع - Create a branch </div>
 
 
 <div dir="rtl"> بما اننا عايزين نعمل تغيير فى الفايل اللى عملناله نسخة على الجهاز.. الأول ننتقل للفولدر اللي لسة نسخينه: </div>


### PR DESCRIPTION
fix typo in Egypt translation version in file README.eg inside translations folder.
The translation of word create was ->"فصل" which mean in Arabic cut while the suitable word should be ->"إنشاء " which mean in Arabic create 