### PR TITLE
Correction to git add command in SE translation.

### DIFF
--- a/translations/README.se.md
+++ b/translations/README.se.md
@@ -74,7 +74,7 @@ Ge kommando `git status` i projektkatalogen för att se de ändringar du gjort.
 Lägg till dina ändringar genom att använda kommando `git add -A`:
 
 ```
-git add -A
+git add Contributors.md
 ```
 
 Commita dina ändringar genom att använda `git commit`:


### PR DESCRIPTION
Hi there!

Was just about to show this repository for my son so he can start learn git, but found something in the Swedish translation (which he will use) that bothered me a bit.
Most other translations (skimmed through a few) seems to use the same as the English default description, while the Swedish uses `-A` instead of the filename in the `git add` command example.

As we all know `-A` or `*` is quite bad practice, _especially_ for beginners, which made me want to fix this before even sending it to my son! ;)