### PR TITLE
correction of a typo in README.fr.md

### DIFF
--- a/translations/README.fr.md
+++ b/translations/README.fr.md
@@ -47,7 +47,7 @@ Déplacez-vous dans le répertoire du projet nouvellement cloné (si vous n'y ê
 ```
 cd first-contributions
 ```
-Maintenant créez une branche avec le commande `git checkout` :
+Maintenant créez une branche avec la commande `git checkout` :
 ```
 git checkout -b <add-votre-nom>
 ```


### PR DESCRIPTION
In README.fr.md 
Change "le commande" by "la commande"