### PR TITLE
Add Homo Algoriticus to Contributors list

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -41,6 +41,7 @@
 - [westtle](https://github.com/westtle)
 - [Pratik Ghosh]
 - [Sreedev](https://github.com/sreedev-ss)
+  [Homo Algoritius](https://github.com/BARarch)
 -[Muhammad Saad]
 Mohammed Yunus
 -[Mohammed Yunus](https://github.com/Y-u-n-u-s)


### PR DESCRIPTION
Hi, I just got my SSH fixed to get you this push.  

This change is for adding "Homo Algoriticus" to the contributors list.  In the branch name (Add-Homo-Algoritius) there is a typo and it differs from my actual name Homo Algoriticus.

Thanks for the Tutorial