### PR TITLE
Remove space that breaks link with lakesidedev

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -1098,7 +1098,7 @@ Rishabh Pandey
 - [Praveen Dias](https://github.com/praveendias1180)
 - [Yashkumar Gupta](https://github.com/yashh1234)
 - [Daniel Ervanda](https://github.com/dnd7)
-- [lakesidedev] (https://github.com/lakesidedev)
+- [lakesidedev](https://github.com/lakesidedev)
 - [Lukas de VIPART](https://github.com/Rekch)
 - [Fei](https://github.com/xegg)
 - [R Sathvik]@DevsocPI


### PR DESCRIPTION
In my first commit and pull request I seem to have accidentally introduced a space in the syntax that makes the link not work. Fixing.