### PR TITLE
Translated title 'First Contributions' into German

### DIFF
--- a/translations/README.de.md
+++ b/translations/README.de.md
@@ -4,7 +4,7 @@
 [![Open Source Helpers](https://www.codetriage.com/roshanjossey/first-contributions/badges/users.svg)](https://www.codetriage.com/roshanjossey/first-contributions)
 
 
-# First Contributions
+# Erste Beiträge
 
 <img align="right" width="300" src="https://firstcontributions.github.io/assets/Readme/fork.png" alt="Repository forken" />
 


### PR DESCRIPTION
In the German translation of README.md, the title 'First Contributions' wasn't translated into German.