### PR TITLE
Update README to add guidance for repointing the remote connection to an SSH URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,15 @@ replacing `your-branch-name` with the name of the branch you created earlier.
   fatal: Authentication failed for 'https://github.com/<your-username>/first-contributions.git/'</pre>
   Go to [GitHub's tutorial](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account) on generating and configuring an SSH key to your account.
 
+  After the SSH tutorial, you may need to repoint the repository clone on your local machine to an SSH URL.
+  To do this, return to your GitHub account, open your forked repository and click on the _Code_ button. Then select _SSH_ and click the _copy to clipboard icon_. In your terminal, type `git remote set-url origin` and paste the ssh url you just copied. run this command.
+
+  For example:
+  ```
+  git remote set-url origin git@github.com:this-is-you/first-contributions.git
+  ```
+  where `this-is-you` is your GitHub username
+
 </details>
 
 ## Submit your changes for review


### PR DESCRIPTION
Addresses #54360 (Password authentification and ssh)

Users who initially clone the repository using the HTTPS url are forced to restart the tutorial using the SSH url. Until the tutorial is edited to instruct users to clone from the SSH url from the start, the proposed changes instruct them to reset the remote connection of the origin to the respective SSH url of their Github fork.