### PR TITLE
Add Luis Tapia Navarro to Contributors list

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -138,6 +138,7 @@
 -[kavearhasi](https://github.com/kavearhasi)
 - [Arturo Lﾃｳpez](https://github.com/arturolopeze)
 - [Albert Arakelyan](https://github.com/AlbertArakelyan)
+- [Luis Tapia Navarro](https://github.com/tapiadot)
 - [Chloe Gavrilovic](https://github.com/cmgvc)
 - [Arslan Asghar](https://github.com/al-arslan)
 - [Ali Ayed](https://github.com/iTzVoko)


### PR DESCRIPTION
Contributor name and link to GitHub profile added to `Contributors.md` file.
* Name: Luis Tapia Navarro
* GitHub handle: @tapiadot