### PR TITLE
Add identity section to git bash windows tutorial and my name to contributors

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -16,6 +16,7 @@
 - [Syed Mudassir Ali](https://github.com/Mudassir10X)
 - [Gaurav Dhiman](https://github.com/gauravdhiman217)
 - [Roy Ataya](https://github.com/RoyAtaya)
+- [Hannes Albert](https://github.com/w8ste)
 - [Oluwatobi Sofela](https://github.com/oluwatobiss)
 - [Lacatus Ciprian](https://github.com/ciprilacatus)
 - [Aman Kumar Nayak](https://github.com/amankumarnayak)

--- a/cli-tool-tutorials/git-bash-windows-tutorial.md
+++ b/cli-tool-tutorials/git-bash-windows-tutorial.md
@@ -35,6 +35,14 @@ Open the git bash application you just downloaded. It should look like the image
 
 <img src="https://firstcontributions.github.io/assets/cli-tool-tutorials/git-bash-windows-tutorial/gb-terminal-1.png" alt="open git bash terminal" />
 
+Now you need to set your name and email. This step is imporpant because every commit you will create uses this
+information.
+```
+git config --global user.name "your username"
+git config --global user.email youremail@example.com
+```
+Replace username with your name and the example email with yours.
+
 Go to the folder that you want to save this project on by uisng this command
 
 `cd <folder>`


### PR DESCRIPTION
### PR description
On the official git website adding your name and email is the first thing you should do, after installing git. Since it was missing from the git-bash-windows tutorial, i added it. 

### Changes
- Added some new information to cli-tool-tutorials/git-bash-windows-tutorial.md
- Added my name to Contributors.md