### PR TITLE
Update 'git checkout' to 'git switch' in README.mx.md

### DIFF
--- a/translations/README.mx.md
+++ b/translations/README.mx.md
@@ -52,14 +52,14 @@ Cambia al directorio del repositorio en tu equipo (si es que no estás ahí ya).
 cd first-contributions
 ```
 
-Ahora crea una rama (*branch*) usando el comando  `git checkout`:
+Ahora crea una rama (*branch*) usando el comando  `git switch`:
 ```
-git checkout -b <añade tu nombre>
+git switch -c <añade tu nombre>
 ```
 
 Por ejemplo:
 ```
-git checkout -b add-juan-perez
+git switch -c add-juan-perez
 ```
 (El nombre de la rama no tiene porqué contener la palabra *add*, pero es razonable que lo tenga porque el objetivo de esta rama es añadir tu nombre a la lista.)
 


### PR DESCRIPTION
This PR updates the 'git checkout' command in README.mx.md to 'git switch -c' to reflect the use of 'git switch' for branch creation, as suggested in the original README.

Thank you for reviewing this change!