### PR TITLE
Add Bernardo Leal to Contributors list

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -3940,6 +3940,7 @@ Akash Abraham
 - [Cesar Casas](https://github.com/Cesarcasas0737)
 - [benqhdri](https://github.com/benqhdri)
 - [Gowri Sankar Kalla](https://github.com/sankarkalla2)
+- [Bernardo Wolff Leal](https://github.com/bwolffleal)
 - [UvrajSB](https://github.com/UvrajSB)
 - [Ashmit Chamoli](https://github.com/ashmitchamoli)
 -[Balaganesh](https://github.com/balaganesh102004)


### PR DESCRIPTION
The name Bernardo Wolff Leal was added in Contributors.md