### PR TITLE
Add Roman KC to Contributors list

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -5158,3 +5158,4 @@ Gauresh Rathi
 - [Dom Polochak](https://github.com/dompolochak)
 - [Pawel Glowacki](https://github.com/pawelglo)
 - [Meep223](https://github.com/meep223)
+- [kcromanpl](https://github.com/kcromanpl)


### PR DESCRIPTION
This PR adds 'Roman KC' and the Github link to the contributor list.