### PR TITLE
Fixed text issues in Vietnamese Github Desktop translation + More detailed information with glossary of terms.

### DIFF
--- a/gui-tool-tutorials/translations/github-desktop-tutorial.vn.md
+++ b/gui-tool-tutorials/translations/github-desktop-tutorial.vn.md
@@ -1,4 +1,4 @@
-_Người dịch: [Ngo Phu Hien](https://github.com/FlopffyGrape)_ (một số đoạn dịch được lấy từ [Tran Ly Vu](https://github.com/tranlyvu))
+_Người dịch: [Ngo Phu Hien](https://github.com/FlopffyGrape)_ (một số đoạn dịch được lấy và chỉnh sửa từ [Tran Ly Vu](https://github.com/tranlyvu))
 
 [![Open Source Love](https://badges.frapsoft.com/os/v1/open-source.svg?v=103)](https://github.com/ellerbrock/open-source-badges/)
 [<img align="right" width="150" src="https://firstcontributions.github.io/assets/gui-tool-tutorials/github-desktop-tutorial/join-slack-team.png">](https://join.slack.com/t/firstcontributors/shared_invite/zt-1hg51qkgm-Xc7HxhsiPYNN3ofX2_I8FA)
@@ -10,9 +10,11 @@ _Người dịch: [Ngo Phu Hien](https://github.com/FlopffyGrape)_ (một số �
 | <img alt="GitHub Desktop" src="https://desktop.github.com/images/desktop-icon.svg" width="200"> | GitHub Desktop Edition |
 | ----------------------------------------------------------------------------------------------- | ---------------------- |
 
-Lần đầu tiên bạn làm điều gì đó có thể gặp nhiều trở ngại. Đặc biệt khi bạn đang cộng tác, sai lầm là điều rất khó tránh khỏi. Chúng tôi muốn đơn giản hóa quy trình học và đóng góp vào những dự án mở.
+Lần đầu tiên bạn làm gì cũng có thể gặp nhiều trở ngại. Khi bạn cộng tác cũng vậy, sai lầm là điều khó tránh khỏi. Vì vậy, chúng tôi muốn đơn giản hóa quy trình học và đóng góp của bạn vào những dự án mở.
 
-Việc đọc hướng dẫn có tác dụng, nhưng có gì tốt hơn là thực sự đóng góp trong môi trường thực tiễn? Dự án này là nhằm mục đích cung cấp sự hướng dẫn và đơn giản hóa cách thức những người mới tham gia đóng góp. Nếu bạn mong muốn thực hiện việc đóng góp đầu tiên của mình, chỉ cần làm theo các bước đơn giản bên dưới.
+Việc đọc hướng dẫn là có tác dụng, nhưng có gì tốt hơn là thực hành một cách thực tế? Dự án này nhằm mục đích hướng dẫn và đơn giản hóa cách để đóng góp vào những dự án mở trên Github cho người mới bắt đầu. Nếu bạn mong muốn thực hiện việc đóng góp đầu tiên của mình, chỉ cần làm theo các bước đơn giản bên dưới.
+
+Nếu bạn muốn hiểu rõ hơn về cách Git và Github hoạt động, xem **Chú giải thuật ngữ Tiếng Anh** ở cuối trang.
 
 Nếu bạn không có Github Desktop trên máy, [cài đặt](https://desktop.github.com/).
 
@@ -23,13 +25,12 @@ Nếu bạn đang dùng Github Desktop phiên bản 1.0 trở xuống, [nên xem
 ## Copy kho mã nguồn (Fork)
 Copy kho mã nguồn này bằng cách nhấn vào nút Fork đầu trang này. Bản sao kho mã nguồn này sẽ được tạo ra trong tài khoản của bạn.
 
-## Sao chép kho mã nguồn (Clone)
+## Tải kho mã nguồn về máy (Clone)
+Clone sẽ cho phép bạn tải kho mã nguồn (hay còn gọi là repository) về máy. (Download locally)
 
-Bây giờ, hãy sao chép (clone) kho mã nguồn vào máy.
+Để tải kho mã nguồn, nhấn vào "Clone or Download" sau đó nhấn "Open in Desktop"
 
-LƯU Ý: Đừng sao kho mã nguồn gốc. Sao kho mã nguồn mà bạn vừa copy tại tài khoản của bạn
-
-Để sao chép kho mã nguồn, nhấn vào "Clone or Download" sau đó nhấn "Open in Desktop"
+LƯU Ý: Đừng tải kho mã nguồn gốc. Tải kho mã nguồn mà bạn vừa copy tại tài khoản của bạn
 
 <img src="https://firstcontributions.github.io/assets/gui-tool-tutorials/github-desktop-tutorial/dt1-clonetodesktop.png" alt="clone this repository" />
 
@@ -37,39 +38,39 @@ Một cửa sổ sẽ hiện lên. Nhấn vào "Open GitHubDesktop.exe"
 
 <img src="https://firstcontributions.github.io/assets/gui-tool-tutorials/github-desktop-tutorial/dt1-open-githubdesktop.png" alt="clone this repository" />
 
-Sau khi bạn nhấn nút "Open GitHubDesktop.exe", kho mã nguồn sẽ tự động sao chép về máy bạn.
+Sau khi bạn nhấn nút "Open GitHubDesktop.exe", kho mã nguồn sẽ tự động tải về máy bạn.
 
 <img src="https://firstcontributions.github.io/assets/gui-tool-tutorials/github-desktop-tutorial/dt1-downloaded.png" alt="clone this repository" />
 
-Bây giờ bạn đã sao chép thành công kho mã nguồn `first-contributions` trên github vào máy.
+Bây giờ bạn đã tải thành công kho mã nguồn `first-contributions` trên github vào máy.
 
 ## Tạo chi nhánh (Branch)
 
-Bây giờ tạo chi nhánh mới bằng cách nhấn vào biểu tượng "Current branch", sau đó nhấn "New branch"
+Bước tiếp theo, bạn tạo branch mới bằng cách nhấn vào biểu tượng có dòng chữ "Current branch", sau đó nhấn "New branch"
 
 <img src="https://firstcontributions.github.io/assets/gui-tool-tutorials/github-desktop-tutorial/dt1-create-branch.png" alt="make a branch" />
 
-Đặt tên chi nhánh bạn vừa tạo <add-tên-bạn>. Ví dụ, "add-hien-ngo"
+Đặt tên branch vừa tạo là <add-tên-bạn>. Ví dụ, "add-hien-ngo"
 
 <img src="https://firstcontributions.github.io/assets/gui-tool-tutorials/github-desktop-tutorial/dt1-create-branch-name.png" alt="name your branch" />
 
 Nhấn `Create branch`
 
-## Thực hiện những thay đổi cần thiết và chấp nhận những thay đổi này
+## Thực hiện những thay đổi cần thiết và commit các thay đổi vừa làm
 
-Bây giờ mở tập tin Contributors.md và thêm tên của mình vào ở cuối tập tin. Sau đó lưu lại 
+Bây giờ mở tập tin Contributors.md và thêm tên của mình vào ở cuối tập tin. Sau đó lưu lại.
 
 Ví dụ: Nếu tên bạn là Ngo Phu Hien, Bạn sẽ viết như này:
 
-\[Ngo Phu Hien](https://github.com/flopffygrape)
+\[Ngo Phu Hien](https://github.com/hien-ngo29)
 
-lưu ý: https://github.com/flopffygrape là link vào tài khoản Github của bạn
+Lưu ý: https://github.com/hien-ngo29 là link vào tài khoản Github của bạn
 
 Bạn có thể thấy những thay đổi của Contributors.md khi mở GithubDesktop.
 
 <img src="https://firstcontributions.github.io/assets/gui-tool-tutorials/github-desktop-tutorial/dt1-status.png" alt="check status" />
 
-Bây giờ hãy chấp nhận (commit) các thay đổi đó.
+Bây giờ hãy commit các thay đổi đó. Commit sẽ lưu lại các thay đổi bạn vừa làm trên máy, nhưng chưa upload lên kho mã nguồn
 
 Viết tin nhắn thay đổi: "Add `<tên-bạn>` to Contributors list" tại phần __summary__
 
@@ -83,7 +84,8 @@ Ngay bên dưới, bạn sẽ thấy ngay commit đã được tạo.
 
 <img src="https://firstcontributions.github.io/assets/gui-tool-tutorials/github-desktop-tutorial/dt1-commit2.png" alt="commit your changes" />
 
-## Đẩy các thay đổi lên Github
+## Đẩy các thay đổi lên Github (Push)
+Push cho phép bạn upload các thay đổi bạn đã thực hiện trên máy lên kho mã nguồn chính.
 
 Chọn File->Options và đăng nhập vào tài khoản Github.com của bạn. Gõ Github username và mật khẩu.
 
@@ -93,8 +95,8 @@ Nhấn vào nút `Publish` ở góc trên.
 
 <img src="https://firstcontributions.github.io/assets/gui-tool-tutorials/github-desktop-tutorial/dt1-publish1.png" alt="push your changes" />
 
-## Gửi những thay đổi của bạn để xem xét
-Nếu bạn vào trang repository của bạn trên Github, bạn sẽ thấy nút `Compare & pull request`. Nhấn nút đó.
+## Gửi những thay đổi của bạn để xem xét (Pull Request)
+Nếu bạn vào trang kho mã nguồn mà bạn vừa fork trên Github, bạn sẽ thấy nút `Compare & pull request`. Nhấn nút đó.
 
 <img src="https://firstcontributions.github.io/assets/gui-tool-tutorials/github-desktop-tutorial/compare-and-pull.png" alt="create a pull request" />
 
@@ -106,9 +108,9 @@ Tôi sẽ sớm hợp nhất (merge) tất cả các thay đổi của bạn và
 
 ## Đi đâu từ đây?
 
-Chúc mừng! Bạn vừa hoàn thành quy trình tiêu chuẩn copy (fork) -> Sao chép (clone) -> chỉnh sửa (edit) -> yêu cầu kéo (pull request) mà bạn sẽ gặp thường xuyên khi đóng góp!
+Chúc mừng! Bạn vừa hoàn thành quy trình đóng góp tiêu chuẩn: Copy kho mã nguồn (fork) -> Tải về máy (clone) -> Chỉnh sửa (edit) -> Gửi yêu cầu kéo (pull request) mà bạn sẽ làm thường xuyên khi đóng góp những dự án mở!
 
-Hãy ăn mừng đóng góp của bạn và chia sẻ nó với bạn bè và những người theo dõi của bạn bằng cách truy cập [ứng dụng web](https://roshanjossey.github.io/first-contribution/#social-share).
+Hãy ăn mừng đóng góp của bạn và chia sẻ nó với bạn bè và những người theo dõi bằng cách truy cập [ứng dụng web](https://roshanjossey.github.io/first-contribution/#social-share).
 
 Bạn có thể tham gia slack của chúng tôi trong trường hợp bạn cần trợ giúp hoặc có câu hỏi nào. [Tham gia slack](https://join.slack.com/t/firstcontributors/shared_invite/zt-1hg51qkgm-Xc7HxhsiPYNN3ofX2_I8FA).
 
@@ -116,4 +118,17 @@ Bạn có thể tham gia slack của chúng tôi trong trường hợp bạn c�
 
 ## Hướng dẫn sử dụng các công cụ khác
 
-[Back to main page](https://github.com/firstcontributions/first-contributions#tutorials-using-other-tools)
+[Quay lại trang chính](https://github.com/firstcontributions/first-contributions#tutorials-using-other-tools)
+
+## _Chú giải thuật ngữ Tiếng Anh_
+**Fork**: Copy kho mã nguồn của tài khoản Github khác sang tài khoản Github của bạn. Những thay đổi bạn làm trên kho mã nguồn vừa sao chép ở tài khoản sẽ không bị ảnh hưởng ở kho mã nguồn tài khoản bên kia (nhưng nhớ phải tạo branch mới).
+
+**Clone**: Khác với nghĩa Tiếng Anh thông thường là *Sao chép*. Clone trên Git là tải kho mã nguồn về máy (Download locally). Vì thông thường khi thực hiện thay đổi trên kho mã nguồn thì bạn không nên thực hiện trực tiếp trên trang web của kho mã nguồn, tốt nhất nên tải về sau đó làm gì thì làm :).
+
+**Branch**: Nôm na là phiên bản của kho mã nguồn. Có nhiều branch khác nhau do các tài khoản khác fork và tạo hay do chính chủ tạo. Branch thông thường bạn thấy khi mở kho mã nguồn là branch `master` hay `main`. Hay các branch khác là branch phiên bản:`v1`,`v2` ,.. hay branch `wip` (Working in progress (Đang làm) ). Các branch có thể được hợp nhất lại với nhau khi tạo Pull Request và được đồng ý bởi chính chủ. Bạn có thể chọn branch khi Fork, Clone, Commit, Push trên Github nhưng theo mặc định thì branch thông thường tên `master` hay `main`. Như ở hướng dẫn khi bạn fork mã nguồn thì phải tạo branch mới rồi thực hiện thay đổi lên branch đó chứ không thực hiện thay đổi lên branch `main` được (vì bạn không có quyền). Sau đó tạo Pull Request trên trang kho mã nguồn gốc và chờ được chủ đồng ý hợp nhất vào branch `main` .
+
+**Commit**: Lưu các thay đổi mà bạn vừa làm trên máy nhưng chưa upload lên kho mã nguồn chính trên Github. Nói rõ và dể hiểu hơn, khi bạn clone kho mã nguồn lên máy, 1 thư mục ẩn sẽ được tạo là *.git* (để xem thư mục đó bạn chọn View->Hidden Items ở File Explorer). Thư mục này đóng vai trò quản lý các thay đổi bạn vừa làm trên máy hay nói nôm na là *file dự án* của Git. Các thay đổi mà bạn thực hiện sẽ được lưu trong thư mục *.git* đó sau khi bạn commit.
+
+**Push**: Upload các thay đổi bạn vừa làm trên máy lên kho mã nguồn chính. Lưu ý phải commit các thay đổi trước khi push. Bạn có thể tạo nhiều commit rồi push 1 lần.
+
+**Pull Request**: Sau khi bạn Fork một kho mã nguồn ở tài khoản khác và thực hiện thay đổi trên kho mã nguồn của tài khoản bạn. Bạn có thể tạo tin nhắn yêu cầu hợp nhất những thay đổi bạn thực hiện qua kho mã nguồn gốc bên tài khoản kia. Nói dễ hiểu là push các thay đổi của bạn thẳng lên mã nguồn gốc với điều kiện phải được chủ kho mã nguồn đồng ý và chấp nhận. Đây chính là phần thịt của đóng góp các dự án mở trên Github.

--- a/gui-tool-tutorials/translations/github-desktop-tutorial.vn.md
+++ b/gui-tool-tutorials/translations/github-desktop-tutorial.vn.md
@@ -93,7 +93,7 @@ Nhấn vào nút `Publish` ở góc trên.
 
 <img src="https://firstcontributions.github.io/assets/gui-tool-tutorials/github-desktop-tutorial/dt1-publish1.png" alt="push your changes" />
 
-## Gửi những thay đổi của bạn để xem xé
+## Gửi những thay đổi của bạn để xem xét
 Nếu bạn vào trang repository của bạn trên Github, bạn sẽ thấy nút `Compare & pull request`. Nhấn nút đó.
 
 <img src="https://firstcontributions.github.io/assets/gui-tool-tutorials/github-desktop-tutorial/compare-and-pull.png" alt="create a pull request" />
@@ -104,7 +104,7 @@ Bây giờ gửi yêu cầu kéo. (Pull request)
 
 Tôi sẽ sớm hợp nhất (merge) tất cả các thay đổi của bạn vào nhánh chủ (master branch) của project này. Bạn sẽ nhận được email thông báo sau khi các thay đổi đã được hợp nhất.
 
-## Where to go from here?
+## Đi đâu từ đây?
 
 Chúc mừng! Bạn vừa hoàn thành quy trình tiêu chuẩn copy (fork) -> Sao chép (clone) -> chỉnh sửa (edit) -> yêu cầu kéo (pull request) mà bạn sẽ gặp thường xuyên khi đóng góp!
 


### PR DESCRIPTION
A lot of of terms of Git like Clone, Commit, Push,... are really hard to describe in Vietnamese. Nobody will understand these words in Vietnamese. Therefore, I decided to use their original English words and made a glossary of terms to explain.

There are some English sentences that I forgot to translate. Now they're translated.

I have edited the passage to make it more nature for Vietnamese, too!

### Note cho bạn Ziệt Nam
Lỗi chính tả có cái tiêu đề "Xem xé" đổi thành "Xem xét". Mấy cái title có thêm mấy từ Tiếng Anh + Bảng chú giải thuật ngữ để dễ hiểu hơn so với mấy từ Tiếng Việt "Sao chép", "Đẩy",... sẽ gây khó hiểu. Xem thêm ở commit mình.
Cám ơn bạn:)