### PR TITLE
keeping-your-fork-synced-with-this-repository: update branch name for English and Korean

### DIFF
--- a/additional-material/git_workflow_scenarios/keeping-your-fork-synced-with-this-repository.md
+++ b/additional-material/git_workflow_scenarios/keeping-your-fork-synced-with-this-repository.md
@@ -9,13 +9,13 @@ Our second move will be to push your local repo to your GitHub fork. As you've s
 
 Now, let's see how to do it:
 
-First, you must be on your master branch. To know which branch you are on, check the first line of:
+First, you must be on your main branch. To know which branch you are on, check the first line of:
 ```
 git status
 ```
-if you are not already on master:
+if you are not already on main:
 ```
-git checkout master
+git checkout main
 ```
 
 Then you should add my public repo to your git with `add upstream remote-url`:
@@ -27,19 +27,19 @@ This is a way of telling git that another version of this project exists in the 
 git fetch upstream
 ```
 
-You've just fetched the latest version of my fork (`upstream` remote). Now, you need to merge the public repository into your master branch.
+You've just fetched the latest version of my fork (`upstream` remote). Now, you need to merge the public repository into your main branch.
 ```
-git rebase upstream/master
+git rebase upstream/main
 ```
-Here you're merging the public repository with your master branch. Your local machine's master branch is now up-to-date. Lastly, if you push your master branch to your fork, your GitHub fork will also have the changes:
+Here you're merging the public repository with your main branch. Your local machine's main branch is now up-to-date. Lastly, if you push your main branch to your fork, your GitHub fork will also have the changes:
 ```
-git push origin master
+git push origin main
 ```
 Notice here you're pushing to the remote named `origin`.
 
 If you want to fetch and merge the latest changes of my fork (`upstream` remote) to your local branch at same time then you can directly go for:
 ```
-git pull upstream master
+git pull upstream main
 ```
 
 So by now or at this point, all your repositories are up-to-date. Well done! You should do this, every time your GitHub repo tells you that you are a few commits behind.

--- a/additional-material/translations/Korean/keeping-your-fork-synced-with-this-repository.ko.md
+++ b/additional-material/translations/Korean/keeping-your-fork-synced-with-this-repository.ko.md
@@ -7,13 +7,13 @@
 여러분의 두 개의 저장소들을 제 공개 저장소의 최신 상태와 싱크상태를 유지하기 위해서는 제일 먼저여러분의 로컬머신에 위치한 저장소를 제 공개 저장소와 fetch와 merge를 해야합니다.
 두번째는 여러분의 로컬 저장소를 포크된 GitHub의 저장소에 push하는 것 입니다. 이전 과정에서 봤듯이 "pull request"를 요청할 수 있는 곳은 오직 포크된 저장소에서만 가능합니다. 따라서 마지막으로 업데이트 되어야하는 저장소는 포크된 GitHub입니다.
 자, 어떻게하는지 보겠습니다:
-먼저 여러분은 master 브랜치에 위치해 있어야합니다. 현재 어떤 브래치에 있는지 확인합니다.:
+먼저 여러분은 main 브랜치에 위치해 있어야합니다. 현재 어떤 브래치에 있는지 확인합니다.:
 ```
 git status
 ```
-현재 master 브랜치가 아니라면 변경합니다.:
+현재 main 브랜치가 아니라면 변경합니다.:
 ```
-git checkout master
+git checkout main
 ```
 
 제 공개 저장소를 아직 여러분의 git에 추가하지 않았다면 다음 명령으로 추가합니다. `add upstream remote-url`:
@@ -25,14 +25,14 @@ git remote add upstream https://github.com/Roshanjossey/first-contributions
 git fetch upstream
 ```
 
-여러분은 이제 제 포크(upstream remote)에서 최신 버전을 내려 받았습니다. 이제 공개 저장소의 변경된 내용을 여러분의 master 브랜치에 병합해야합니다.
+여러분은 이제 제 포크(upstream remote)에서 최신 버전을 내려 받았습니다. 이제 공개 저장소의 변경된 내용을 여러분의 main 브랜치에 병합해야합니다.
 ```
-git rebase upstream/master
+git rebase upstream/main
 ```
 
-여러분의 master 브랜치와 공개 저장소를 병합하고 나면 이제 여러분의 로컬머신의 master 브랜치는 최신 상태입니다. 마지막으로 여러분의 master 브랜치를 여러분의 포크에 push하게 되면 포크한 GitHub 또한 변경사항들이 반영됩니다.:
+여러분의 main 브랜치와 공개 저장소를 병합하고 나면 이제 여러분의 로컬머신의 main 브랜치는 최신 상태입니다. 마지막으로 여러분의 main 브랜치를 여러분의 포크에 push하게 되면 포크한 GitHub 또한 변경사항들이 반영됩니다.:
 ```
-git push origin master
+git push origin main
 ```
 origin으로 명명된 리모트에 push하는 것에 주의하세요.
 이제 여러분의 모든 저장소가 최신 상태를 유지하게 되었습니다. 


### PR DESCRIPTION
:v: Hello
Hi, happy to submit a pull request here!

🐞 Problem
Having read the file `keeping-your-fork-synced-with-this-repository.md`, I noticed that the writer assumes the default branch available is `master` whereas the default branch actually available is `main`. 

🎯 Goal
This would help users who are reading the tutorials have an easier time understanding the markdown document,

💡 Possible solutions
I suggest we keep the documents up-to-date.