### PR TITLE
Add Mihir to Contributors list

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -4,6 +4,7 @@
 - [Eunbi-Sung]
 - [Shailesh Chauhan](https://github.com/sh1lezh) **Hey My first contri** Connect with me [X.com](https://x.com/sh1lezh) [Linkedin](https://linkedin.com/in/shaileshcn)
 - [Rudra]
+-[Mihir](https://github.com/MIHIRstoic)***first time***
 - [Arul MUrugan](https://github.com/ArulMurugan13)
 - [frankfolabi](https://github.com/frankfolabi) ***DevOps Engineer*** Connect with me on ![LinkedIn](https://linkedin.com/in/frankfolabi) 
 - [SHIVAM](https://github.com/GH-Shivam007)


### PR DESCRIPTION
This pull request adds Alonzo Church to the list of contributors in the CONTRIBUTORS.md file. Alonzo Church was a prominent logician and mathematician known for his contributions to mathematical logic and the development of lambda calculus.
