### PR TITLE
Add Capri Caviedes to Contributors list

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -3528,6 +3528,7 @@ Jasmine
 - [Gabriel Fernandes](https://github.com/gabrielfernandeswebdev)
 - [Lakshya Mishra](https://github.com/mishrlaksh)
 - [Subin Mariyadas](https://github.com/subin170)
+- [Capri Caviedes](https://github.com/caprivm)
 - [Albert Byrone](https://github.com/Albert-Byrone)
 - [zurfjereluhmie](https://github.com/zurfjereluhmie)
 - [Rishan Thangaraj](https://github.com/rishant3441)


### PR DESCRIPTION
Add [Capri Caviedes](https://github.com/caprivm) to the `Contributors.md` list.