### PR TITLE
Remove Slack links from bengali translation

### DIFF
--- a/docs/translations/README.bn.md
+++ b/docs/translations/README.bn.md
@@ -1,5 +1,4 @@
 [![Open Source Love](https://badges.frapsoft.com/os/v1/open-source.svg?v=103)](https://github.com/ellerbrock/open-source-badges/)
-[<img align="right" width="150" src="https://firstcontributions.github.io/assets/Readme/join-slack-team.png">](https://join.slack.com/t/firstcontributors/shared_invite/zt-1hg51qkgm-Xc7HxhsiPYNN3ofX2_I8FA)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 [![Open Source Helpers](https://www.codetriage.com/roshanjossey/first-contributions/badges/users.svg)](https://www.codetriage.com/roshanjossey/first-contributions)
 
@@ -121,8 +120,6 @@ git push origin -u <your-new-branch-name>
 ## এরপর কী করব?
 
 আপনার অবদানের আনন্দ উপভোগ করুন এবং [ওয়েব অ্যাপ](https://firstcontributions.github.io/#social-share)-এর মাধ্যমে বন্ধু ও অনুসরণকারীদের সাথে শেয়ার করুন।
-
-কোনো সহায়তার প্রয়োজন হলে বা আপনার কোনো প্রশ্ন থাকলে আপনি আমাদের স্ল্যাক টিমে যুক্ত হতে পারেন। [স্ল্যাক টিমে যোগ দিন](https://firstcontributions.herokuapp.com)
 
 এখন আপনি অন্যান্য প্রজেক্টগুলোতেও অবদান রাখতে পারেন। আপনার সুবিধার্থে আমরা সহজ সমস্যা সম্বলিত প্রজেক্টগুলোর একটি তালিকা তৈরি করেছি। ওয়েব অ্যাপে [প্রজেক্টগুলোর তালিকা](https://firstcontributions.github.io/#project-list) দেখুন।
 


### PR DESCRIPTION
Removed the Slack link from the Bengali (README.bn.md) translation as part of the effort to move away from using Slack.

Deleted the Slack image link and text link in the "এরপর কী করব?" (What to do next?) section.

Verified the changes locally to ensure the file renders correctly without the Slack references.

This PR addresses #94081