### PR TITLE
#94134 . Remove Slack link from Egyptian Arabic translation 

### DIFF
--- a/docs/translations/README.eg.md
+++ b/docs/translations/README.eg.md
@@ -1,5 +1,5 @@
 [![Open Source Love](https://badges.frapsoft.com/os/v1/open-source.svg?v=103)](https://github.com/ellerbrock/open-source-badges/)
-[<img align="right" width="150" src="https://firstcontributions.github.io/assets/Readme/join-slack-team.png">](https://join.slack.com/t/firstcontributors/shared_invite/zt-1hg51qkgm-Xc7HxhsiPYNN3ofX2_I8FA)
+
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 [![Open Source Helpers](https://www.codetriage.com/roshanjossey/first-contributions/badges/users.svg)](https://www.codetriage.com/roshanjossey/first-contributions)
 # <div dir="rtl">مساهمتك الأولى</div>
@@ -138,7 +138,7 @@ git push origin "add-your-name"
  احتفل بأول مساهمة ليك، أعمل شير مع صحابك ومتابعينك عن طريق زيارة <a href="https://firstcontributions.github.io/#social-share">الموقع دة. </a>
 </div>
 
-<div dir="rtl">ممكن تنضم للفريق على Slack لو حابب تساعد او عندك أسئلة. <a href="https://join.slack.com/t/firstcontributors/shared_invite/zt-1hg51qkgm-Xc7HxhsiPYNN3ofX2_I8FA"> إنضم للفريق على Slack</a></div>
+<div dir="rtl">ممكن تنضم للفريق على Slack لو حابب تساعد او عندك أسئلة. ></div>
 
 <br>
 


### PR DESCRIPTION
This pull request addresses the issue of removing the Slack link in the Egyptian Arabic translation file. It ensures there are no references to Slack, as mentioned in the issue.

Before 
![image](https://github.com/user-attachments/assets/e98c2f44-4ef1-4edb-b11a-f605e8e78fb6)

After
![image](https://github.com/user-attachments/assets/54d3d2f6-962c-4908-8a5e-8391693a6f4a)
