### PR TITLE
Replace Slack link with code contributions link in Portuguese Readme

### DIFF
--- a/docs/translations/README.pt-pt.md
+++ b/docs/translations/README.pt-pt.md
@@ -90,7 +90,7 @@ Quando puder incorporarei as tuas mudanças no Branch principal (master) deste p
 
 Celebra as tuas contribuições e partilha-as com amigos e seguidores através da [web app](https://firstcontributions.github.io/#social-share).
 
- Podes também juntar-te à nossa equipa no Slack caso precises de alguma ajuda ou tenhas alguma dúvida. [Junta-te à nossa equipa no Slack](https://join.slack.com/t/firstcontributors/shared_invite/zt-1hg51qkgm-Xc7HxhsiPYNN3ofX2_I8FA).
+Se quiseres praticar mais, acede a [code contributions](https://github.com/roshanjossey/code-contributions).
 
 Aqui estão alguns repositórios com Issues a nível de principiante em que tu podes ajudar a resolver. Vai em frente e clica nos repositórios para saber mais.
 


### PR DESCRIPTION

This pull request addresses issue [#95170](https://github.com/firstcontributions/first-contributions/issues/95170). It replaces the Slack link in the "Where to go from here" section of the Portuguese (pt-pt) translation of the README.md file with a link to the code contributions repository, as seen in the English version of the README.

Changes made:

    Removed the Slack link in the README.pt-pt.md file.
    Added a link to the code contributions repository, mirroring the English README.

This update ensures that the Portuguese translation has consistent content with the main README.md.