### PR TITLE
Remove Slack link from Egyptian Arabic translation

### DIFF
--- a/docs/translations/README.eg.md
+++ b/docs/translations/README.eg.md
@@ -1,5 +1,4 @@
 [![Open Source Love](https://badges.frapsoft.com/os/v1/open-source.svg?v=103)](https://github.com/ellerbrock/open-source-badges/)
-
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 [![Open Source Helpers](https://www.codetriage.com/roshanjossey/first-contributions/badges/users.svg)](https://www.codetriage.com/roshanjossey/first-contributions)
 # <div dir="rtl">مساهمتك الأولى</div>


### PR DESCRIPTION
This PR removes the slack link from Egyptian Arabic translation file as mentioned in issue #94134 
