### PR TITLE
Removed slack link from macedonian translation

### DIFF
--- a/docs/translations/README.mk.md
+++ b/docs/translations/README.mk.md
@@ -1,5 +1,4 @@
 [![Open Source Love](https://badges.frapsoft.com/os/v1/open-source.svg?v=103)](https://github.com/ellerbrock/open-source-badges/)
-[<img align="right" width="150" src="https://firstcontributions.github.io/assets/Readme/join-slack-team.png">](https://join.slack.com/t/firstcontributors/shared_invite/zt-1hg51qkgm-Xc7HxhsiPYNN3ofX2_I8FA)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 [![Open Source Helpers](https://www.codetriage.com/roshanjossey/first-contributions/badges/users.svg)](https://www.codetriage.com/roshanjossey/first-contributions)
 


### PR DESCRIPTION
I fixed a issue by removing the slack link from the Macedonian translation the issue is: #95735

- [ x ] I had fun going through this tutorial (ノ^o^)ノ and learned on the way ٩(＾◡＾)۶
- [ x ] There are some things I'd like to improve in this tutorial. I have written them below.
- [ x ] There were steps where I had errors while following this tutorial. I have written them below.


#95735 