### PR TITLE
Fixes #97496: remove Slack links in Ukrainian translation

### DIFF
--- a/docs/translations/README.ua.md
+++ b/docs/translations/README.ua.md
@@ -1,5 +1,4 @@
 [![Open Source Love](https://firstcontributions.github.io/open-source-badges/badges/open-source-v1/open-source.svg)](https://github.com/firstcontributions/open-source-badges)
-[<img align="right" width="150" src="https://firstcontributions.github.io/assets/Readme/join-slack-team.png">](https://join.slack.com/t/firstcontributors/shared_invite/zt-1hg51qkgm-Xc7HxhsiPYNN3ofX2_I8FA)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 [![Open Source Helpers](https://www.codetriage.com/roshanjossey/first-contributions/badges/users.svg)](https://www.codetriage.com/roshanjossey/first-contributions)
 
@@ -117,8 +116,6 @@ git push -г origin <your-branch-name>
 Вітаю! Ви щойно виконали стандартний робочий процес _fork -> clone -> edit -> pull request_, з яким ви часто стикаєтеся як контрибутор!
 
 Відзначте свій внесок і поділіться ним із друзями та читачами, перейшовши до [веб-програми](https://firstcontributions.github.io/#social-share).
-
-Ви можете приєднатися до нашої команди Slack, якщо вам потрібна допомога або якщо виникнуть запитання. [Приєднайтеся до команди Slack](https://firstcontributors.slack.com/join/shared_invite/zt-29qhyr9lt-Bi7WLbgGIFqV7aCEG_grvg#/shared-invite/email).
 
 Тепер давайте почнемо робити внески в інші проекти. Ми склали список проектів із простими проблемами, з яких ви можете почати. Перегляньте [список проектів у веб-додатку](https://firstcontributions.github.io/#project-list).
 


### PR DESCRIPTION
This PR removes outdated Slack references from the Ukrainian translation files.

- [x] Comment below about what you've started working on.
- [x] Add, commit, push your changes.
- [x] Submit a pull request and add this in comments - Addresses #

Addresses #97496
