### PR TITLE
fix: replace Slack link with contribution guide in Catalan translation

### DIFF
--- a/docs/translations/README.ca.md
+++ b/docs/translations/README.ca.md
@@ -107,7 +107,7 @@ Enhorabona! Acabes de completar el procés de treball principal que et trobaràs
 
 Ara, celebra la teva contribució i comparteix-la amb els teus amics i seguidors anant a [la web](https://firstcontributions.github.io/#social-share).
 
-Si vols contribuir al projecte, pots començar amb aquesta [guia per contribuir al codi](https://github.com/firstcontributions/first-contributions/blob/main/README.md#how-to-contribute).
+Si vols contribuir al projecte, pots començar amb aquesta [guia per contribuir al codi](https://github.com/roshanjossey/code-contributions).
 
 A continuació, et pots preparar per contribuir a altres projectes. Hem reunit una llista de projectes amb tasques (*issues*) pendents fàcils per tal de poder començar. Fes un cop d'ull a [la llista de projectes aquí](https://firstcontributions.github.io/#project-list).
 

--- a/docs/translations/README.ca.md
+++ b/docs/translations/README.ca.md
@@ -107,7 +107,7 @@ Enhorabona! Acabes de completar el procés de treball principal que et trobaràs
 
 Ara, celebra la teva contribució i comparteix-la amb els teus amics i seguidors anant a [la web](https://firstcontributions.github.io/#social-share).
 
-Podeu unir-vos al nostre equip d'*slack* en cas de que necessiteu ajuda o tingueu alguna pregunta. [Unir-se a l'equip d'slack](https://join.slack.com/t/firstcontributors/shared_invite/zt-1hg51qkgm-Xc7HxhsiPYNN3ofX2_I8FA).
+Si vols contribuir al projecte, pots començar amb aquesta [guia per contribuir al codi](https://github.com/firstcontributions/first-contributions/blob/main/README.md#how-to-contribute).
 
 A continuació, et pots preparar per contribuir a altres projectes. Hem reunit una llista de projectes amb tasques (*issues*) pendents fàcils per tal de poder començar. Fes un cop d'ull a [la llista de projectes aquí](https://firstcontributions.github.io/#project-list).
 


### PR DESCRIPTION
Addresses #94531 - This replaces the Slack invite link in the 'Where to go from here' section of the Catalan translation with a link to the code contribution guide, similar to what's shown in the English Readme.

Before submitting this pull request, check the changes to see it's only the changes you made intentionally
If there are changes to other lines you didn't make deliberately, it's possible that your IDE made the changes with a utility like prettier.
Next time, make sure that you only add your changes by using `git add -p` and rather than `git add Contributors.md`

If you're doing something in the checklist below, put an `x` inside `[ ]` so that `- [ ]` becomes `- [x]`

- [x] I had fun going through this tutorial (ノ^o^)ノ and learned on the way ٩(＾◡＾)۶
- [ ] There are some things I'd like to improve in this tutorial. I have written them below.
- [ ] There were steps where I had errors while following this tutorial. I have written them below.
