### PR TITLE
Fix Code-Contributions Repository link formatting in German README

### DIFF
--- a/docs/translations/README.de.md
+++ b/docs/translations/README.de.md
@@ -110,7 +110,7 @@ Glückwunsch! Du hast so eben den Standard-Workflow _Fork -> Clone -> Edit -> Pu
 
 Feiere deinen Beitrag zum Projekt und teile ihn mit deinen Freunden und Followern über unsere [Web-App](https://firstcontributions.github.io/#social-share).
 
-Wenn Du noch mehr üben möchtest, schau Dir das [Code-Contributions Repository] (https://github.com/roshanjossey/code-contributions) an.
+Wenn Du noch mehr üben möchtest, schau Dir das [Code-Contributions Repository](https://github.com/roshanjossey/code-contributions) an.
 Falls du jetzt zu anderen Projekten beitragen möchtest, dann haben wir für dich eine Liste von einfachen, ersten Issues zusammengestellt, an denen du arbeiten kannst. Diese Projekt-Liste findest du [in unserer Web-App](https://firstcontributions.github.io/#project-list).
 
 ## Tutorials mit anderen Tools


### PR DESCRIPTION
his PR fixes the formatting of the Code-Contributions Repository link in the 'Wie geht es weiter?' section of the German translation of the README.
Removed the space in the Markdown link.
Ensured there is no Slack link in this section.
Issue reference:
Addresses #94132
