### PR TITLE
fix:replace Slack link with code contributions link in Deutsch README

### DIFF
--- a/docs/translations/README.de.md
+++ b/docs/translations/README.de.md
@@ -110,8 +110,9 @@ Glückwunsch! Du hast so eben den Standard-Workflow _Fork -> Clone -> Edit -> Pu
 
 Feiere deinen Beitrag zum Projekt und teile ihn mit deinen Freunden und Followern über unsere [Web-App](https://firstcontributions.github.io/#social-share).
 
-Wenn Du noch mehr üben möchtest, schau Dir das [Code-Contributions Repository](https://github.com/roshanjossey/code-contributions) an.
+Wenn Du noch mehr üben möchtest, schau Dir das [Code-Contributions Repository](https://github.com/firstcontributions/first-contributions) an.  
 Falls du jetzt zu anderen Projekten beitragen möchtest, dann haben wir für dich eine Liste von einfachen, ersten Issues zusammengestellt, an denen du arbeiten kannst. Diese Projekt-Liste findest du [in unserer Web-App](https://firstcontributions.github.io/#project-list).
+
 
 ## Tutorials mit anderen Tools
 


### PR DESCRIPTION
This PR updates the German translation of the README file (README.de.md) to remove the outdated Slack invitation link from the "Where to go from here" section.
Instead, it adds a link to the official First Contributions code contributions repository, consistent with the English README.
This change improves clarity and directs contributors to the right resource for practicing contributions.