### PR TITLE
Add SSH Key Setup Guide and Link It in Issue Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue-template.md
+++ b/.github/ISSUE_TEMPLATE/issue-template.md
@@ -12,7 +12,10 @@ assignees: Roshanjossey
 
 🐞 **Problem**
 <!--- Provide a detailed description of the change or addition you are proposing -->
-<!--- If it is a feature or a bug, what problem is it solving-->
+<!--- If it is a feature or a bug, what problem is it solving -->
+
+<!--- ⚠️ If you're facing an SSH error like `Permission denied (publickey)`, -->
+<!--- please refer to this guide to set up your SSH key: [SSH Key Setup Guide](../ssh-key-setup.md) -->
 
 🎯 **Goal**
 <!--- Why is this change important to you? How would you use it? -->

--- a/.github/ssh-key-setup.md
+++ b/.github/ssh-key-setup.md
@@ -1,0 +1,95 @@
+
+
+##  SSH Key Generation Guide (Markdown Content):
+
+```markdown
+##  How to Generate and Add an SSH Key to GitHub
+
+If you're seeing an error like:
+
+```
+
+[git@github.com](mailto:git@github.com): Permission denied (publickey)
+
+````
+
+You probably haven’t added an SSH key yet. Follow these steps:
+
+---
+
+### Step 1: Generate SSH Key
+
+Open **Git Bash** and run:
+
+```bash
+ssh-keygen -t ed25519 -C "your_email@example.com"
+````
+
+Press `Enter` to accept the default save location. Optionally, add a passphrase.
+
+---
+
+### Step 2: Copy the Public Key
+
+Run:
+
+```bash
+cat ~/.ssh/id_ed25519.pub
+```
+
+Copy the full output that starts with `ssh-ed25519`.
+
+---
+
+###  Step 3: Add Key to GitHub
+
+1. Go to [https://github.com/settings/keys](https://github.com/settings/keys)
+2. Click **New SSH Key**
+3. Give it a title like `My Laptop`
+4. Paste the key and click **Add SSH Key**
+5. Leave it set to **Authentication** (not Signing)
+
+---
+
+### Step 4: Test the SSH Connection
+
+Run:
+
+```bash
+ssh -T git@github.com
+```
+
+Expected result:
+
+```
+Hi username! You've successfully authenticated, but GitHub does not provide shell access.
+```
+
+---
+
+Now you can clone or push using SSH without issues. ✅
+
+````
+
+---
+
+## ✅ Step 4: Commit and Push
+
+```bash
+git add .
+git commit -m "Added SSH key generation guide"
+git push origin main
+````
+
+Or if you're working on a separate branch:
+
+```bash
+git checkout -b add-ssh-guide
+git push origin add-ssh-guide
+```
+
+Then make a pull request if needed.
+
+---
+
+

--- a/Contributors.md
+++ b/Contributors.md
@@ -107,6 +107,7 @@
 - [Hady Hefny](https://github.com/hadyhefny)
 - [AkashGGaonkar]
 - [Omesh Ramlagan](https://github.com/kristovr)
+- [Measum-Shah](https://github.com/Measum-Shah)
 - [Ricky Lam](https://github.com/RickyLam11)
 - [Ayush Premchand](http://github.com/APremchand)
 - [Lucas Lopes](http://github.com/olucaslopes)


### PR DESCRIPTION
## 📌 Description

This pull request adds a detailed `ssh-key-setup.md` guide to help beginners resolve the common SSH error: `Permission denied (publickey)` when cloning or pushing to GitHub.

It also updates the `.github/ISSUE_TEMPLATE/issue-template.md` file to reference this guide in the 🐞 Problem section. This will help contributors who face SSH setup issues while trying to contribute for the first time.

## 📂 Changes Made
- Added a new `ssh-key-setup.md` file in the root directory
- Updated `issue-template.md` to include a link to the SSH guide
- Ensured the issue template now points to the guide if users report SSH-related problems

## 📈 Motivation

New contributors often face SSH issues due to missing or incorrect key setup. This change provides clear guidance and improves the overall onboarding experience.

## 🧪 Testing

- Verified file structure is correct
- Markdown renders properly in GitHub
- SSH instructions were manually tested and confirmed working

---