### PR TITLE
 Remove outdated Slack invite link from Albania README.al.md

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -1,5 +1,6 @@
 # Contributors
 - [Aditya](https://github.com/itxadii) Lets Connect coders🚀.
+- [Lokeek Lokhande](https://github.com/lokhandelokeek11) Dm and lets connect !
 - [Max](https://github.com/mxpfister) I'm bored
 - [HaiJeng](https://github.com/HaiJeng) Making this commit on 2025-06-12 16:22:49
 - [Raunak](https://github.com/Raunakkumarsingh2005) Making this commit on 12.06.2025 If you are new to open source like me let's get in touch. Connect with me on X(https://x.com/RaunakKumar_27). Dm and we are good to go.

--- a/docs/translations/README.al.md
+++ b/docs/translations/README.al.md
@@ -114,7 +114,7 @@ Urime! Ti sapo ke kompletuar procesin _fork -> clone -> edit -> PR_ që do ta ha
 
 Festoje kontributin tënd dhe ndaje me shokët dhe ndjekësit duke shkuar te [web aplikacioni](https://firstcontributions.github.io/#social-share).
 
-Ti mund të bashkohesh në ekipin tonë në slack nëse të duhet ndihmë ose nëse ke ndonjë pyetje. [Bashkohu ekipit në slack](https://join.slack.com/t/firstcontributors/shared_invite/zt-1hg51qkgm-Xc7HxhsiPYNN3ofX2_I8FA).
+Ti mund të bashkohesh në ekipin tonë në slack nëse të duhet ndihmë ose nëse ke ndonjë pyetje. [Bashkohu ekipit në slack]
 
 Tani të të ndihmojmë që të kontribuosh në projekte tjera. Ne kemi krijuar një listë projektesh me probleme të lehta tek të cilat mund të fillosh. Shiko [listën e projekteve në web apliacion](https://firstcontributions.github.io/#project-list).
 

--- a/docs/translations/README.guj.md
+++ b/docs/translations/README.guj.md
@@ -1,5 +1,4 @@
 ﻿[![Open Source Love](https://badges.frapsoft.com/os/v1/open-source.svg?v=103)](https://github.com/ellerbrock/open-source-badges/)
-[<img align="right" width="150" src="https://firstcontributions.github.io/assets/Readme/join-slack-team.png">](https://join.slack.com/t/firstcontributors/shared_invite/zt-1hg51qkgm-Xc7HxhsiPYNN3ofX2_I8FA)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 [![Open Source Helpers](https://www.codetriage.com/roshanjossey/first-contributions/badges/users.svg)](https://www.codetriage.com/roshanjossey/first-contributions)
 


### PR DESCRIPTION
### Summary

Removed the outdated Slack invite link from `docs/translations/README.al.md` as it is no longer valid. This ensures the document stays up-to-date and avoids confusion for new contributors reading the Albania Translation.

### Changes Made
- Removed Slack invite image and link at the top of the file.
- Ensured formatting remains consistent after removal.

### Related Issue
Fixes #98997
Let me know if there are any additional changes in it !
