### PR TITLE
Fix: Updated Slack link to code contributions link in Uzbek README

### DIFF
--- a/docs/translations/README.uz.md
+++ b/docs/translations/README.uz.md
@@ -127,6 +127,9 @@ Tabriklayman! Siz horizgina contributor sifatida tez-tez uchraydigan standard is
 
 Hissangizni nishonlang va [web app](https://firstcontributions.github.io/#social-share)ga o'tish orqali do'stlaringizga va ergashuvchilaringizga ulashing.
 
+Agar ko‘proq mashq qilishni xohlasangiz, [code contributions](https://github.com/firstcontributions/first-contributions/blob/main/code-contributions.md) faylini ko‘rib chiqing.
+
+
 
 Agar koʻproq mashq qilishni istasangiz, [kod hissalarini](https://github.com/roshanjossey/code-contributions) tekshiring.
 


### PR DESCRIPTION
Addresses #94526

Replaced the outdated Slack link in the Uzbek translation with a link to the code contributions page, as done in the English README.

This ensures consistency across translations and helps contributors find the correct next steps.

✅ I had fun going through this tutorial and learned a lot!
