### PR TITLE
Remove outdated Slack link from Punjabi translation

### DIFF
--- a/docs/translations/README.pb.md
+++ b/docs/translations/README.pb.md
@@ -1,5 +1,4 @@
 [![Open Source Love](https://badges.frapsoft.com/os/v1/open-source.svg?v=103)](https://github.com/ellerbrock/open-source-badges/)
-[<img align="right" width="150" src="https://firstcontributions.github.io/assets/Readme/join-slack-team.png">](https://join.slack.com/t/firstcontributors/shared_invite/zt-1hg51qkgm-Xc7HxhsiPYNN3ofX2_I8FA)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 
 # ਪਹਿਲਾ ਯੋਗਦਾਨ


### PR DESCRIPTION
just removed slack link from punjabi translation