### PR TITLE
Remove Slack link from Czech translation README

### DIFF
--- a/docs/translations/README.cs.md
+++ b/docs/translations/README.cs.md
@@ -1,5 +1,4 @@
 [![Open Source Love](https://badges.frapsoft.com/os/v1/open-source.svg?v=103)](https://github.com/ellerbrock/open-source-badges/)
-[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 [![Open Source Helpers](https://www.codetriage.com/roshanjossey/first-contributions/badges/users.svg)](https://www.codetriage.com/roshanjossey/first-contributions)
 
 


### PR DESCRIPTION
This pull request removes the outdated Slack link from the Czech translation README.

Addresses #94087
