### PR TITLE
 add note about avoiding Prettier merge conflicts with git add -p

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -83,3 +83,16 @@ If you're making changes to a translation, please request a review from our prev
 | 中文 | [Chinese (Simplified)](../translations/README.zh-cn.md) | [<img width="100" src="https://avatars2.githubusercontent.com/u/6414741?s=400&v=4" alt="@yuzhoujr" />](https://github.com/yuzhoujr) |
 | 中文 | [Chinese (Traditional)](../translations/README.zh-tw.md) | [<img width="100" src="https://avatars2.githubusercontent.com/u/27748281?s=460&v=4" alt="@WeiChienHsu" />](https://github.com/WeiChienHsu) |
 | Zulu | [Zulu](../translations/README.zu.md) | [<img width="100" src="https://avatars.githubusercontent.com/u/36197725?v=4" alt="@zecollokaris" />](https://github.com/zecollokaris) []() |
+
+
+---
+
+# Avoiding Prettier Merge Conflicts
+
+If you use VS Code with the Prettier extension, it may automatically reformat files.
+This can sometimes cause merge conflicts when contributing.
+
+To stage only the exact changes you want, use:
+
+```bash
+git add -p


### PR DESCRIPTION
🐞 Problem
When using VS Code with the Prettier extension, it may automatically reformat files.
This can cause unnecessary merge conflicts when contributing.

🎯 Goal
To help new contributors avoid merge conflicts caused by Prettier’s auto-formatting.

💡 Solution
Added a section at the end of CONTRIBUTING.md explaining how to use:
    git add -p
so contributors can stage only the exact changes they intend to commit.

📋 Checklist
-I had fun going through this tutorial and learned on the way 
