### PR TITLE
docs(pt-pt): add missing reference to Git GUI tools

### DIFF
--- a/docs/translations/README.pt-pt.md
+++ b/docs/translations/README.pt-pt.md
@@ -102,3 +102,14 @@ Aqui estão alguns repositórios com Issues a nível de principiante em que tu p
 | <a href="../gui-tool-tutorials/github-desktop-tutorial.md"><img alt="GitHub Desktop" src="https://desktop.github.com/images/desktop-icon.svg" width="100"></a> | <a href="../gui-tool-tutorials/github-windows-vs2017-tutorial.md"><img alt="Visual Studio 2017" src="https://upload.wikimedia.org/wikipedia/commons/c/cd/Visual_Studio_2017_Logo.svg" width="100"></a> | <a href="../gui-tool-tutorials/gitkraken-tutorial.md"><img alt="GitKraken" src="https://firstcontributions.github.io/assets/gui-tool-tutorials/gitkraken-tutorial/gk-icon.png" width="100"></a> | <a href="../gui-tool-tutorials/github-windows-vs-code-tutorial.md"><img alt="VS Code" src="https://upload.wikimedia.org/wikipedia/commons/1/1c/Visual_Studio_Code_1.35_icon.png" width=100></a> | <a href="../gui-tool-tutorials/sourcetree-macos-tutorial.md"><img alt="Sourcetree App" src="https://wac-cdn.atlassian.com/dam/jcr:81b15cde-be2e-4f4a-8af7-9436f4a1b431/Sourcetree-icon-blue.svg" width=100></a> | <a href="../gui-tool-tutorials/github-windows-intellij-tutorial.md"><img alt="IntelliJ IDEA" src="https://upload.wikimedia.org/wikipedia/commons/thumb/9/9c/IntelliJ_IDEA_Icon.svg/512px-IntelliJ_IDEA_Icon.svg.png" width=100></a> |
 | --- | --- | --- | --- | --- | --
 | [GitHub Desktop](../gui-tool-tutorials/github-desktop-tutorial.md) | [Visual Studio 2017](../gui-tool-tutorials/github-windows-vs2017-tutorial.md) | [GitKraken](../gui-tool-tutorials/gitkraken-tutorial.md) | [Visual Studio Code](../gui-tool-tutorials/github-windows-vs-code-tutorial.md) | [Atlassian Sourcetree](../gui-tool-tutorials/sourcetree-macos-tutorial.md) | [IntelliJ IDEA](../gui-tool-tutorials/github-windows-intellij-tutorial.md) |
+## Usar Ferramentas Gráficas (Git GUI Tools)
+
+Se não estiver confortável com a linha de comandos, pode usar ferramentas gráficas para fazer contribuições no GitHub.  
+Algumas opções populares são:
+
+- [Sourcetree](https://www.sourcetreeapp.com/)  
+- [GitHub Desktop](https://desktop.github.com/)  
+- [GitKraken](https://www.gitkraken.com/)  
+
+Estas ferramentas facilitam a visualização das mudanças, staging e commits sem precisar escrever comandos.
+


### PR DESCRIPTION
Problem
The Portuguese (Portugal) translation of the tutorial was missing a reference to Git GUI tools. This might confuse beginners who are not comfortable with the command line.

Solution
Added a section in README.pt-pt.md introducing popular Git GUI tools such as GitHub Desktop, Sourcetree, and GitKraken.

Impact
This will make the tutorial more beginner-friendly for Portuguese-speaking contributors by providing alternatives to the command line.