### PR TITLE
docs: clarify clone instructions and fix "apliacion" typo

### DIFF
--- a/docs/translations/README.al.md
+++ b/docs/translations/README.al.md
@@ -24,7 +24,7 @@ Për të bërë fork këtë repozitor kliko butonin fork në majë të kësaj fa
 
 Tani klonoje në pajisjen tënde repozitorin që bëre fork. Shko te llogaria e GitHub, hap forked repository, kliko butonin Code dhe pastaj kliko ikonën _copy to clipboard_.
 
-Hap terminalin dhe bëje run git komandën në vazhdim:
+Hap terminalin dhe ekzekuto komandën Git më poshtë për të klonuar repozitorin në kompjuterin tënd:
 
 ```
 git clone "url që sapo ke kopjuar"
@@ -116,7 +116,7 @@ Festoje kontributin tënd dhe ndaje me shokët dhe ndjekësit duke shkuar te [we
 
 Nëse dëshiron më shumë praktikë, shiko [kontributet e kodit](https://github.com/roshanjossey/code-contributions)
 
-Tani të të ndihmojmë që të kontribuosh në projekte tjera. Ne kemi krijuar një listë projektesh me probleme të lehta tek të cilat mund të fillosh. Shiko [listën e projekteve në web apliacion](https://firstcontributions.github.io/#project-list).
+Tani të të ndihmojmë që të kontribuosh në projekte tjera. Ne kemi krijuar një listë projektesh me probleme të lehta tek të cilat mund të fillosh. Shiko [listën e projekteve në web aplikacion](https://firstcontributions.github.io/#project-list).
 
 ### [Materiale shtesë](additional-material/git_workflow_scenarios/additional-material.md)
 


### PR DESCRIPTION
- Improved wording for cloning instructions in README.al.md:
  - Replaced "bëje run git komandën" with "ekzekuto komandën Git më poshtë" for clearer Albanian phrasing
  - Added guidance for copying URL and running git clone
- Corrected spelling of "apliacion" to "aplikacion" for accuracy

Before submitting this pull request, check the changes to see it's only the changes you made intentionally
If there are changes to other lines you didn't make deliberately, it's possible that your IDE made the changes with a utility like prettier.
Next time, make sure that you only add your changes by using `git add -p` and rather than `git add Contributors.md`

If you're doing something in the checklist below, put an `x` inside `[ ]` so that `- [ ]` becomes `- [x]`

- [ ] I had fun going through this tutorial (ノ^o^)ノ and learned on the way ٩(＾◡＾)۶
- [x] There are some things I'd like to improve in this tutorial. I have written them below.
- [ ] There were steps where I had errors while following this tutorial. I have written them below.