### PR TITLE
Add Clay LaMothe to Contributors list

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -988,6 +988,7 @@
 - [Rushikesh Deshmukh](https://github.com/Mrx207)
 - [Rushikesh Jadhav](https://github.com/Rushi543)
 - [SANJAY KUMAR](https://github.com/sanjaydeepak)
+- [Clay LaMothe](https://github.com/ClayLaMothe)
 - [Sagar Patel](https://github.com/sagarpatel279)
 - [Sahil Gulunjkar](https://github.com/Sahil4757)
 - [Sakshi Jaiswal](https://github.com/Sakshijazz)


### PR DESCRIPTION
Added Clay LaMothe and github URL to list of contributors.

- [x] I had fun going through this tutorial (ノ^o^)ノ and learned on the way ٩(＾◡＾)۶