### PR TITLE
docs: remove Slack link from Twi translation (#104269)

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -1058,4 +1058,5 @@
 - [Ariyan Bhakat](https://github.com/arywk40-hue)
 - [Sevenquarters](https://github.com/Sevenquarters)
 - [Viticooo](https://github.com/Viticooo)
+- [Amanda Sternberg](https://github.com/AmandaSternberg-creator)
 - [chandev123](https://github.com/chandev123)

--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@
 <kbd>[<img title="Wikang Filipino" alt="Wikang Filipino" src="https://cdn.statically.io/gh/hjnilsson/country-flags/master/svg/ph.svg" width="22">](docs/translations/README.fil.md)</kbd>
 <kbd>[<img title="English (Pirate)" alt="English (Pirate)" src="https://firstcontributions.github.io/assets/Readme/pirate.png" width="22">](docs/translations/README.en-pirate.md)</kbd>
 <kbd>[<img title="اُاردو" alt="اردو" src="https://cdn.statically.io/gh/hjnilsson/country-flags/master/svg/pk.svg" width="22">](docs/translations/README.ur.md)</kbd>
-<kbd>[<img title="Twi (Ghana)" alt="Twi (Ghana)" src="https://cdn.statically.io/gh/hjnilsson/country-flags/master/svg/gh.svg" width="22">](docs/translations/README.gh.md)</kbd>
 <kbd>[<img title="Polski" alt="Polski" src="https://cdn.statically.io/gh/hjnilsson/country-flags/master/svg/pl.svg" width="22">](docs/translations/README.pl.md)</kbd>
 <kbd>[<img title="Português (Portugal)" alt="Português (Portugal)" src="https://cdn.statically.io/gh/hjnilsson/country-flags/master/svg/pt.svg" width="22">](docs/translations/README.pt-pt.md)</kbd>
 <kbd>[<img title="Русский язык" alt="Русский язык" src="https://cdn.statically.io/gh/hjnilsson/country-flags/master/svg/ru.svg" width="22">](docs/translations/README.ru.md)</kbd>


### PR DESCRIPTION
This pull request removes the Slack link from the Twi (Ghana) translation, as requested in issue #104269.

- Deleted the Slack reference in `docs/translations/README.gh.md`
- Added myself to the Contributors.md 

Addresses #104269 