### PR TITLE
Fix/remove Slack link in Nepali README translation

### DIFF
--- a/docs/translations/README.np.md
+++ b/docs/translations/README.np.md
@@ -201,7 +201,8 @@ git push -u origin add-ram-regmi
 
 तपाईंले योगदान(contribution) दिनु भएकोमा खुशी मनाउनुहोस् र [web app](https://firstcontributions.github.io/#social-share) मा गएर आफ्नो friends and follower हरूमा पनि शेयर गर्नुहोस् ।
 
-तपाइँलाई कुनै पनि मद्दत चाहिन्छ वा कुनै प्रश्न छ भने तपाइँ हाम्रो slack team मा सामेल हुन सक्नुहुनेछ। [join slack team](https://join.slack.com/t/firstcontributors/shared_invite/zt-1hg51qkgm-Xc7HxhsiPYNN3ofX2_I8FA).
+यदि तपाईंलाई थप अभ्यास चाहियो भने, [कोड योगदानहरू](https://github.com/roshanjossey/code-contributions) हेर्नुहोस्।
+
 
 अब तपाईले अन्य प्रोजेक्टहरूमा योगदान दिन सुरु गर्नुहोस्। हामीले तपाईंले गर्न सक्नुहुने सजिलो समस्याहरू(issues)को साथमा प्रोजेक्टहरूको सूची संकलन गरेका छौ हेर्नुहोस् ।. [list of projects in the web app](https://firstcontributions.github.io/#project-list)।
 


### PR DESCRIPTION
Fixes #104436 
Removed Slack link from Nepali README translation.
