### PR TITLE
Removed slack link in Malayama translation #104591

### DIFF
--- a/docs/translations/README.ml.md
+++ b/docs/translations/README.ml.md
@@ -1,5 +1,4 @@
 [![Open Source Love](https://badges.frapsoft.com/os/v1/open-source.svg?v=103)](https://github.com/ellerbrock/open-source-badges/)
-[<img align="right" width="150" src="https://firstcontributions.github.io/assets/Readme/join-slack-team.png">](https://join.slack.com/t/firstcontributors/shared_invite/zt-1hg51qkgm-Xc7HxhsiPYNN3ofX2_I8FA)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 [![Open Source Helpers](https://www.codetriage.com/roshanjossey/first-contributions/badges/users.svg)](https://www.codetriage.com/roshanjossey/first-contributions)
 


### PR DESCRIPTION
Problem

- The Malayama translation README still contained a Slack link, but the project is moving away from Slack.

Solution

- Removed the Slack link from docs/translations/README.ml.md.

Notes

- This PR removes the outdated Slack reference and helps keep the documentation up to date.

Addresses #104591 