### PR TITLE
Remove slack link in Bosnian translation

### DIFF
--- a/docs/translations/README.me.md
+++ b/docs/translations/README.me.md
@@ -1,5 +1,4 @@
 [![Open Source Love](https://firstcontributions.github.io/open-source-badges/badges/open-source-v1/open-source.svg)](https://github.com/firstcontributions/open-source-badges)
-[<img align="right" width="150" src="assets/join-slack-team.png">](https://join.slack.com/t/firstcontributors/shared_invite/zt-1hg51qkgm-Xc7HxhsiPYNN3ofX2_I8FA)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 [![Open Source Helpers](https://www.codetriage.com/roshanjossey/first-contributions/badges/users.svg)](https://www.codetriage.com/roshanjossey/first-contributions)
 


### PR DESCRIPTION
Deleted the Slack team join image and link from the translations README.

Addresses #104593
- [x ] I had fun going through this tutorial (ノ^o^)ノ and learned on the way ٩(＾◡＾)۶
