### PR TITLE
Removed slack link in Armenian translation #104534

### DIFF
--- a/docs/translations/README.hy.md
+++ b/docs/translations/README.hy.md
@@ -122,7 +122,6 @@ git push origin <add-your-name>
 
 Նշեք ձեր ներդրումը և կիսվեք այն ձեր ընկերների և հետևորդների հետ՝ այցելելով [web app](https://firstcontributions.github.io/#social-share).
 
-Դուք կարող եք միանալ մեր Slack թիմին, եթե որևէ հարց կամ օգնության կարիք ունեք։ [Միանալ slack թիմին](https://join.slack.com/t/firstcontributors/shared_invite/zt-1hg51qkgm-Xc7HxhsiPYNN3ofX2_I8FA).
 
 Հիմա կարող եք ձեր ներդրումն ունենալ այլ նախագծերում։ Մենք կազմել ենք հեշտ խնդիրներ ունեցող նախագծերի ցանկ, որոնցից կարող եք սկսել: Համեցեք [վեբ հավելվածի նախագծերի ցանկը](https://firstcontributions.github.io/#project-list).
 


### PR DESCRIPTION
Problem

- The Armenian translation README still contained a Slack link, but the project is moving away from Slack.

Solution

- Removed the Slack link from docs/translations/README.hy.md.

Notes

- This PR removes the outdated Slack reference and helps keep the documentation up to date.
Addresses #104534