### PR TITLE
Remove Slack links from Georgian translation  #104268

### DIFF
--- a/docs/translations/README.ge.md
+++ b/docs/translations/README.ge.md
@@ -1,5 +1,4 @@
 [![Open Source Love](https://badges.frapsoft.com/os/v1/open-source.svg?v=103)](https://github.com/ellerbrock/open-source-badges/)
-[<img align="right" width="150" src="https://firstcontributions.github.io/assets/Readme/join-slack-team.png">](https://join.slack.com/t/firstcontributors/shared_invite/zt-1hg51qkgm-Xc7HxhsiPYNN3ofX2_I8FA)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 [![Open Source Helpers](https://www.codetriage.com/roshanjossey/first-contributions/badges/users.svg)](https://www.codetriage.com/roshanjossey/first-contributions)
 
@@ -109,7 +108,6 @@ git push origin <add-your-branch-name>
 
 აღნიშნე და გაუზიარე მეგობრებს შენი წარმატება [ამ ლინკზე გადასვლით](https://firstcontributions.github.io/#social-share).
 
-[შემოგვიერთდი slack-ზე](https://join.slack.com/t/firstcontributors/shared_invite/zt-1hg51qkgm-Xc7HxhsiPYNN3ofX2_I8FA).
 
 თუ კონტრიბუციების სხვაგან შეტანაც გინდა, ჩვენ შენთვის შედარებით მარტივად გასაგები პროექტები შევარჩიეთ,  [რომლებსაც აქ ნახავ](https://firstcontributions.github.io/#project-list).
 


### PR DESCRIPTION
Problem

The georgian translation README still contained a Slack link, but the project is moving away from Slack.
Solution

Removed the Slack link from docs/translations/README.my.md.
Notes

This PR removes the outdated Slack reference and helps keep the documentation up to date.
Addresses  #104268