### PR TITLE
Remove Slack invitation from README.fr.md

### DIFF
--- a/docs/translations/README.fr.md
+++ b/docs/translations/README.fr.md
@@ -172,5 +172,3 @@ Ceci n'est pas nécessaire, mais le nom de la branche montre que son objectif es
 | [GitHub Desktop](../gui-tool-tutorials/github-desktop-tutorial.md) | [Visual Studio 2017](../gui-tool-tutorials/github-windows-vs2017-tutorial.md) | [GitKraken](../gui-tool-tutorials/gitkraken-tutorial.md) | [Visual Studio Code](../gui-tool-tutorials/github-windows-vs-code-tutorial.md) | [Atlassian Sourcetree](../gui-tool-tutorials/sourcetree-macos-tutorial.md) | [IntelliJ IDEA](../gui-tool-tutorials/github-windows-intellij-tutorial.md) |
 
 ## Où aller ensuite ?
-
-Vous pouvez aussi rejoindre notre équipe sur Slack au cas où vous auriez besoin d'aide ou auriez des questions.  [Rejoindre l'équipe sur  Slack](https://join.slack.com/t/firstcontributors/shared_invite/zt-1hg51qkgm-Xc7HxhsiPYNN3ofX2_I8FA)


### PR DESCRIPTION
Isuuue #104813 
Removed Slack team invitation from French README.

