### PR TITLE
fix(tr): Remove all Slack links from Turkish README

### DIFF
--- a/docs/translations/README.tr.md
+++ b/docs/translations/README.tr.md
@@ -1,5 +1,4 @@
 [![Open Source Love](https://badges.frapsoft.com/os/v1/open-source.svg?v=103)](https://github.com/ellerbrock/open-source-badges/)
-[<img align="right" width="150" src="https://firstcontributions.github.io/assets/Readme/join-slack-team.png">](https://join.slack.com/t/firstcontributors/shared_invite/zt-1hg51qkgm-Xc7HxhsiPYNN3ofX2_I8FA)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 [![Open Source Helpers](https://www.codetriage.com/roshanjossey/first-contributions/badges/users.svg)](https://www.codetriage.com/roshanjossey/first-contributions)
 

--- a/docs/translations/README.tr.md
+++ b/docs/translations/README.tr.md
@@ -118,8 +118,6 @@ Tebrikler! Katkıda bulunan kişi olarak sıklıkla karşılaşacağınız stand
 
 Sunduğunuz katkının coşkusunu yaşamak ve bunu arkadaşlarınız ve takipçilerinizle paylaşmak için [bu bağlantıdaki](https://firstcontributions.github.io/#social-share) uygulamamızı kullanabilirsiniz.
 
-Bir sorunuz veya yardıma ihtiyacınız olursa Slack takımımıza katılabilirsiniz. [Slack takımına katıl](https://firstcontributions.herokuapp.com)
-
 Artık diğer projelere katkı sunmaya hazırsınız. Çözmeye başlayabileceğiniz giriş seviyesindeki konulara (issue) sahip projeleri [sizin için derledik](https://firstcontributions.github.io/#project-list).
 
 ### [Ek bilgi](../additional-material/git_workflow_scenarios/additional-material.md)


### PR DESCRIPTION
Hey team,

This PR addresses the request to remove all Slack links from the Turkish documentation, aligning with the project's goal of moving communication off that platform.

I've removed both the image link at the top and the text link at the bottom of the `README.tr.md` file.

---

### Referenced Issue

| Category | Detail |
| :--- | :--- |
| 🐞 **Problem** | We're moving away from using slack |
| 🎯 **Goal** | Have no links to slack |
| 💡 **Action Taken** | Removed all Slack-related images and invitation links from `docs/translations/README.tr.md`. |

---

Let me know if you need any changes!