### PR TITLE
docs: Add code contributions link to Greek README

### DIFF
--- a/docs/translations/README.gr.md
+++ b/docs/translations/README.gr.md
@@ -1,4 +1,4 @@
-﻿[![Open Source Love](https://badges.frapsoft.com/os/v1/open-source.svg?v=103)](https://github.com/ellerbrock/open-source-badges/)
+[![Open Source Love](https://badges.frapsoft.com/os/v1/open-source.svg?v=103)](https://github.com/ellerbrock/open-source-badges/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 [![Open Source Helpers](https://www.codetriage.com/roshanjossey/first-contributions/badges/users.svg)](https://www.codetriage.com/roshanjossey/first-contributions)
 
@@ -8,7 +8,7 @@
 
 Αν δεν είστε εξοικειωμένοι με τη γραμμή εντολών, [εδώ υπάρχουν σεμινάρια που χρησιμοποιούν γραφικά εργαλεία](https://github.com/firstcontributions/first-contributions#tutorials-using-other-tools)
 
-<img align="right" width="300" src="https://firstcontributions.github.io/assets/Readme/fork.png" alt="fork this repository" />
+<img align="right" alt="fork this repository" width="300"/>
 
 Εάν δεν έχετε εγκατεστημένο το git στον υπολογιστή σας, [εγκαταστήστε το](https://help.github.com/articles/set-up-git/)
 
@@ -18,7 +18,7 @@
 
 ## Αποθηκεύστε τοπικά το αποθετήριο (clone)
 
-<img align="right" width="300" src="https://firstcontributions.github.io/assets/Readme/clone.png" alt="clone this repository" />
+<img align="right" alt="clone this repository" width="300"/>
 
 Τώρα αντιγράψτε το αποθετήριο στον υπολογιστή σας. Κάντε κλικ στο κουμπί `Clone or download` και μετά στο εικονίδιο δεξιά από το σύνδεσμο για αντιγραφή στο πρόχειρο.
 
@@ -30,7 +30,7 @@ git clone "σύνδεσμος που μόλις αντιγράψατε"
 
 Όπου "σύνδεσμος αποθετηρίου" (χωρίς τα εισαγωγικά) είναι ο σύνδεσμος για αυτό το αποθετήριο. Ανατρέξτε στα προηγούμενα βήματα για να βρείτε αυτόν τον σύνδεσμο.
 
-<img align="right" width="300" src="https://firstcontributions.github.io/assets/Readme/copy-to-clipboard.png" alt="copy URL to clipboard" />
+<img align="right" alt="copy URL to clipboard" width="300"/>
 
 Για παράδειγμα:
 
@@ -80,7 +80,7 @@ git switch -c add-alonzo-church
 
 Σιγουρευτείτε ότι δεν υπάρχει κενό ανάμεσα στα `](` . Αποθηκεύστε το αρχείο και κλείστε το.
 
-<img align="right" width="450" src="https://firstcontributions.github.io/assets/Readme/git-status.png" alt="git status" />
+<img align="right" alt="git status" width="450"/>
 
 Εάν πάτε στο φάκελο του αποθετηρίου και γράψετε την εντολή `git status`, θα δείτε ότι υπάρχουν κάποιες αλλαγές. Προσθέστε αυτές τις αλλαγές χρησιμοποιώντας την εντολή `git add`.
 
@@ -110,11 +110,11 @@ git push origin <add-your-name>
 
 Εάν πάτε στο αποθετήριο (repository) στο github θα δείτε ένα κουμπί με τίτλο `Compare & pull request`. Κάντε κλικ σε αυτό το κουμπί.
 
-<img style="float: right;" src="https://firstcontributions.github.io/assets/Readme/compare-and-pull.png" alt="create a pull request" />
+<img alt="create a pull request" style="float: right;"/>
 
 Τώρα υποβάλετε το pull request.
 
-<img style="float: right;" src="https://firstcontributions.github.io/assets/Readme/submit-pull-request.png" alt="submit pull request" />
+<img alt="submit pull request" style="float: right;"/>
 
 Σύντομα θα ενσωματώσω όλες τις αλλαγές σας στο master branch του προγράμματος. Θα ειδοποιηθείτε με email όταν οι αλλαγές που κάνατε ενσωματωθούν.
 
@@ -124,12 +124,14 @@ git push origin <add-your-name>
 
 Γιορτάστε και μοιραστείτε την συνεισφορά σας με τους φίλους και τους ακόλουθους σας πηγαίνοντας στο [web app](https://firstcontributions.github.io/#social-share).
 
+Αν θέλετε περισσότερη εξάσκηση, δείτε τις [συνεισφορές κώδικα](https://github.com/roshanjossey/code-contributions).
+
 Τώρα μπορείτε να ξεκινήσετε να συνεισφέρετε και σε άλλα project. Έχουμε φτιάξει μια λίστα από project με εύκολα προβλήματα για να ξεκινήσετε. Δείτε εδώ [τη λίστα με τα project](https://firstcontributions.github.io/#project-list).
 
 ### [Επιπρόσθετο υλικό](../additional-material/git_workflow_scenarios/additional-material.md)
 
 ## Εκπαιδευτικό Υλικό Χρήσης Άλλων Εργαλείων
 
-| <a href="../gui-tool-tutorials/github-desktop-tutorial.md"><img alt="GitHub Desktop" src="https://desktop.github.com/images/desktop-icon.svg" width="100"></a> | <a href="../gui-tool-tutorials/github-windows-vs2017-tutorial.md"><img alt="Visual Studio 2017" src="https://upload.wikimedia.org/wikipedia/commons/c/cd/Visual_Studio_2017_Logo.svg" width="100"></a> | <a href="../gui-tool-tutorials/gitkraken-tutorial.md"><img alt="GitKraken" src="https://firstcontributions.github.io/assets/gui-tool-tutorials/gitkraken-tutorial/gk-icon.png" width="100"></a> | <a href="../gui-tool-tutorials/github-windows-vs-code-tutorial.md"><img alt="VS Code" src="https://upload.wikimedia.org/wikipedia/commons/1/1c/Visual_Studio_Code_1.35_icon.png" width=100></a> | <a href="../gui-tool-tutorials/sourcetree-macos-tutorial.md"><img alt="Sourcetree App" src="https://wac-cdn.atlassian.com/dam/jcr:81b15cde-be2e-4f4a-8af7-9436f4a1b431/Sourcetree-icon-blue.svg" width=100></a> | <a href="../gui-tool-tutorials/github-windows-intellij-tutorial.md"><img alt="IntelliJ IDEA" src="https://upload.wikimedia.org/wikipedia/commons/thumb/9/9c/IntelliJ_IDEA_Icon.svg/512px-IntelliJ_IDEA_Icon.svg.png" width=100></a> |
+| <a href="../gui-tool-tutorials/github-desktop-tutorial.md"><img alt="GitHub Desktop" width="100"/></a> | <a href="../gui-tool-tutorials/github-windows-vs2017-tutorial.md"><img alt="Visual Studio 2017" width="100"/></a> | <a href="../gui-tool-tutorials/gitkraken-tutorial.md"><img alt="GitKraken" width="100"/></a> | <a href="../gui-tool-tutorials/github-windows-vs-code-tutorial.md"><img alt="VS Code" width="100"/></a> | <a href="../gui-tool-tutorials/sourcetree-macos-tutorial.md"><img alt="Sourcetree App" width="100"/></a> | <a href="../gui-tool-tutorials/github-windows-intellij-tutorial.md"><img alt="IntelliJ IDEA" width="100"/></a> |
 | --- | --- | --- | --- | --- | --- |
 | [GitHub Desktop](../gui-tool-tutorials/github-desktop-tutorial.md) | [Visual Studio 2017](../gui-tool-tutorials/github-windows-vs2017-tutorial.md) | [GitKraken](../gui-tool-tutorials/gitkraken-tutorial.md) | [Visual Studio Code](../gui-tool-tutorials/github-windows-vs-code-tutorial.md) | [Atlassian Sourcetree](../gui-tool-tutorials/sourcetree-macos-tutorial.md) | [IntelliJ IDEA](../gui-tool-tutorials/github-windows-intellij-tutorial.md) |


### PR DESCRIPTION
## Description

This PR adds the missing code contributions link to the Greek translation (README.gr.md) in the "Where to go from here?" (Τι να κάνετε τώρα;) section.

## Changes
- Added line: "Αν θέλετε περισσότερη εξάσκηση, δείτε τις [συνεισφορές κώδικα](https://github.com/roshanjossey/code-contributions)." 
- This matches the English README structure and provides the missing link between the web app social share link and the project list link

## Addresses
Closes #104824

## Checklist
- [x] I had fun going through this tutorial (ノ^o^)ノ and learned on the way ٩(＾◡＾)۶
- [ ] There are some things I'd like to improve in this tutorial. I have written them below.
- [ ] There were steps where I had errors while following this tutorial. I have written them below.