### PR TITLE
Slack replaced in JP

### DIFF
--- a/docs/translations/README.ja.md
+++ b/docs/translations/README.ja.md
@@ -103,7 +103,7 @@ GitHub上であなたのリポジトリに行くと、`Compare & pull request`�
 
 初めてのオープンソースへの貢献を祝って友達やフォロワーに[このウェブアプリ](https://firstcontributions.github.io/#social-share)を使ってシェアしましょう。
 
-もし何かしら質問があるようでしたら[私たちのSlack team](https://firstcontributors.slack.com/join/shared_invite/enQtMzE1MTYwNzI3ODQ0LTZiMDA2OGI2NTYyNjM1MTFiNTc4YTRhZTg4OWZjMzA0ZWZmY2UxYzVkMzI1ZmVmOWI4ODdkZWQwNTM2NDVmNjY)に入ってください。
+さらに練習したい場合は、[コードの貢献](https://github.com/roshanjossey/code-contributions)を確認してください。
 
 他のプロジェクトへの貢献を始めましょう。簡単なイシューが立てられているプロジェクトのリストを作りました。ウェブアプリで[プロジェクトリスト](https://firstcontributions.github.io/#project-list)を確認してみてください。
 


### PR DESCRIPTION
## Summary of my changes

### Description 
This PR intends to replace the slack link with the code contributions link in the Japanese translation version of README.ja.md file.

### Related Issue
fix #104816

### PR Checklist

- [x] I have replaced the slack link with the code contributions link.
