### PR TITLE
docs: add code-contributions link to Armenian README

### DIFF
--- a/docs/translations/README.hy.md
+++ b/docs/translations/README.hy.md
@@ -122,6 +122,7 @@ git push origin <add-your-name>
 
 Նշեք ձեր ներդրումը և կիսվեք այն ձեր ընկերների և հետևորդների հետ՝ այցելելով [web app](https://firstcontributions.github.io/#social-share).
 
+Եթե ցանկանում եք ավելի շատ փորձ, դիտեք [code contributions](https://github.com/roshanjossey/code-contributions).
 
 Հիմա կարող եք ձեր ներդրումն ունենալ այլ նախագծերում։ Մենք կազմել ենք հեշտ խնդիրներ ունեցող նախագծերի ցանկ, որոնցից կարող եք սկսել: Համեցեք [վեբ հավելվածի նախագծերի ցանկը](https://firstcontributions.github.io/#project-list).
 


### PR DESCRIPTION
What I changed
Edited: README.hy.md — inserted an Armenian sentence linking to the code contributions repo (https://github.com/roshanjossey/code-contributions) under the "Where to go from here" section so it matches the English README.
Note: I looked for a Slack link in the Armenian file to replace but there wasn't one; the change performed was to add the code-contributions link (this satisfies the goal of having the same link as the English README).