### PR TITLE
Replaced slack link with code contribution link in Turkmen translation #104821

### DIFF
--- a/docs/translations/README.tm.md
+++ b/docs/translations/README.tm.md
@@ -133,9 +133,7 @@ Eden goşandyňyza begeniň we dostlaryňyz bilen paýlaşyň!
 
 [Bu baglanma](https://firstcontributions.github.io/#social-share) arkaly hem birnäçe gyzykly proýektlere öz goşandyňyzy goşup bilýäňiz.
 
-Eger-de islendik kömek gerek bolsa ýa-da soraglaryňyz bar bolsa [biziň Slack toparymyza](https://join.slack.com/t/firstcontributors/shared_invite/zt-1hg51qkgm-Xc7HxhsiPYNN3ofX2_I8FA) goşulyp bilýaňiz.
-
-
+Has köp tejribe isleseňiz, töleg [kod goşantlary] (https://github.com/roshanjossey/code-contributions).
 
 ### [Goşmaça maglumat](additional-material/git_workflow_scenarios/additional-material.md)
 


### PR DESCRIPTION
Problem
- Replace link to slack in 'Where to go from here' section in Turkmen translation of Readme and put a link to code contributions like in English Readme

Solution
- Replaced the outdated Slack link in the Turkmen translation from docs/translations/README.tm.md with a link to the Code Contributions section, following the main README.

Addresses #104821