### PR TITLE
Removed slack links Zulu translation #104809

### DIFF
--- a/docs/translations/README.tm.md
+++ b/docs/translations/README.tm.md
@@ -133,9 +133,7 @@ Eden goşandyňyza begeniň we dostlaryňyz bilen paýlaşyň!
 
 [Bu baglanma](https://firstcontributions.github.io/#social-share) arkaly hem birnäçe gyzykly proýektlere öz goşandyňyzy goşup bilýäňiz.
 
-Eger-de islendik kömek gerek bolsa ýa-da soraglaryňyz bar bolsa [biziň Slack toparymyza](https://join.slack.com/t/firstcontributors/shared_invite/zt-1hg51qkgm-Xc7HxhsiPYNN3ofX2_I8FA) goşulyp bilýaňiz.
-
-
+Has köp tejribe isleseňiz, töleg [kod goşantlary] (https://github.com/roshanjossey/code-contributions).
 
 ### [Goşmaça maglumat](additional-material/git_workflow_scenarios/additional-material.md)
 

--- a/docs/translations/README.zul.md
+++ b/docs/translations/README.zul.md
@@ -1,5 +1,4 @@
 [![Open Source Love](https://badges.frapsoft.com/os/v1/open-source.svg?v=103)](https://github.com/ellerbrock/open-source-badges/)
-[<img align="right" width="150" src="https://firstcontributions.github.io/assets/Readme/join-slack-team.png">](https://join.slack.com/t/firstcontributors/shared_invite/zt-1hg51qkgm-Xc7HxhsiPYNN3ofX2_I8FA)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 [![Open Source Helpers](https://www.codetriage.com/roshanjossey/first-contributions/badges/users.svg)](https://www.codetriage.com/roshanjossey/first-contributions)
 
@@ -116,7 +115,6 @@ Siyakuhalalisela! Usanda kuqedela umshini ojwayelekile -> clone -> edit -> PR uk
 
 Gubha umnikelo wakho bese uwabelana nabangani bakho nabalandeli ngokuya kuhlelo [lokusebenza lewebhu](https://firstcontributions.github.io/#social-share).
 
-Ungakwazi ukujoyina ithimba lethu elihle uma kwenzeka udinga noma yiluphi usizo noma unemibuzo. [Joyina ithimba le-slack](https://join.slack.com/t/firstcontributors/shared_invite/zt-1hg51qkgm-Xc7HxhsiPYNN3ofX2_I8FA).
 
 Manje ake siqale ngokunikela ngeminye imiklamo. Senze uhlu lwamaphrojekthi ngezinkinga ezilula ongaqala ngazo. Hlola  [uhlu lwamaphrojekthi kuhlelo lokusebenza lewebhu .](https://firstcontributions.github.io/#project-list).
 


### PR DESCRIPTION
Problem
- The Zulu translation README still contained Slack links, but the project is moving away from Slack.

Solution
- Removed the Slack link from docs/translations/README.zul.md.

Goal
- This PR removes the outdated Slack reference as requested in issue #104809 