### PR TITLE
Replaced slack link with code contribution link in Turkmen translation #104821

### DIFF
--- a/docs/translations/README.tm.md
+++ b/docs/translations/README.tm.md
@@ -133,8 +133,7 @@ Eden goşandyňyza begeniň we dostlaryňyz bilen paýlaşyň!
 
 [Bu baglanma](https://firstcontributions.github.io/#social-share) arkaly hem birnäçe gyzykly proýektlere öz goşandyňyzy goşup bilýäňiz.
 
-Eger-de islendik kömek gerek bolsa ýa-da soraglaryňyz bar bolsa [biziň Slack toparymyza](https://join.slack.com/t/firstcontributors/shared_invite/zt-1hg51qkgm-Xc7HxhsiPYNN3ofX2_I8FA) goşulyp bilýaňiz.
-
+Eger siz köpräk tälim almak isleseňiz, [kode goşant](https://github.com/roshanjossey/code-contributions).
 
 
 ### [Goşmaça maglumat](additional-material/git_workflow_scenarios/additional-material.md)


### PR DESCRIPTION
Problem
- markdown format of link is wrong because of space between ] and (
- translation looks wrong

Solution
- fixed the space between the markdown format 
- improved translation

Addresses #104821 