### PR TITLE
Fix/alan/swedish readme

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -10,6 +10,7 @@
 - [Mohit Bansal](https://github.com/WorkMohit17)
 - [Umasankar Varadati](https://github.com/umasankarvaradati)
 - [Salmaan M](https://github.com/Salmaan-M)
+- [Alan Titus](https://github.com/Alantitus)
 - [Pathmesh G](https://github.com/Pathmesh)
 - [ِAhmed Elsherif](https://github.com/ahmedelsherif-osama)
 - [Manasvi Jain](https://github.com/MJ-thunder)

--- a/docs/translations/README.se.md
+++ b/docs/translations/README.se.md
@@ -1,5 +1,4 @@
 [![Open Source Love](https://badges.frapsoft.com/os/v1/open-source.svg?v=103)](https://github.com/ellerbrock/open-source-badges/)
-[<img align="right" width="150" src="https://firstcontributions.github.io/assets/Readme/join-slack-team.png">](https://join.slack.com/t/firstcontributors/shared_invite/zt-1hg51qkgm-Xc7HxhsiPYNN3ofX2_I8FA)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 [![Open Source Helpers](https://www.codetriage.com/roshanjossey/first-contributions/badges/users.svg)](https://www.codetriage.com/roshanjossey/first-contributions)
 


### PR DESCRIPTION
Addresses #104794 

Changes
Removed link to slack in Swedish translation.
