### PR TITLE
Replace Slack link with code contributions link in Greek README (#104…

### DIFF
--- a/docs/translations/README.gr.md
+++ b/docs/translations/README.gr.md
@@ -122,7 +122,8 @@ git push origin <add-your-name>
 
 Συγχαρητήρια! Μόλις ολοκληρώσατε την τυπική ροή εργασιών _fork -> clone -> edit -> pull request_ που θα συναντήσετε συχνά ως συνεργάτης! 
 
-Γιορτάστε και μοιραστείτε την συνεισφορά σας με τους φίλους και τους ακόλουθους σας πηγαίνοντας στο [web app](https://firstcontributions.github.io/#social-share).
+Δείτε εδώ [τη λίστα με τα project](https://github.com/firstcontributions/first-contributions)
+
 
 Τώρα μπορείτε να ξεκινήσετε να συνεισφέρετε και σε άλλα project. Έχουμε φτιάξει μια λίστα από project με εύκολα προβλήματα για να ξεκινήσετε. Δείτε εδώ [τη λίστα με τα project](https://firstcontributions.github.io/#project-list).
 


### PR DESCRIPTION
Replaced the Slack link in the "Where to go from here" section of the Greek README with the code contributions repo link, following the English README.

Addresses #104824
