### PR TITLE
Update README.tm.md

### DIFF
--- a/docs/translations/README.tm.md
+++ b/docs/translations/README.tm.md
@@ -133,7 +133,8 @@ Eden goşandyňyza begeniň we dostlaryňyz bilen paýlaşyň!
 
 [Bu baglanma](https://firstcontributions.github.io/#social-share) arkaly hem birnäçe gyzykly proýektlere öz goşandyňyzy goşup bilýäňiz.
 
-Eger-de islendik kömek gerek bolsa ýa-da soraglaryňyz bar bolsa [biziň Slack toparymyza](https://join.slack.com/t/firstcontributors/shared_invite/zt-1hg51qkgm-Xc7HxhsiPYNN3ofX2_I8FA) goşulyp bilýaňiz.
+Eger-de islendik kömek gerek bolsa ýa-da soraglaryňyz bar bolsa [biziň code-contributions toparymyza](https://github.com/firstcontributions/code-contributions) goşulyp bilýaňiz.
+
 
 
 


### PR DESCRIPTION
Remove link to Slack in the "Where to go from here" section of the Turkmen translation (README.tm.md) and replaces it with a link to the code contributions repository.

Addresses #104821

