### PR TITLE
Name with no GitHub Link

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -813,7 +813,6 @@
 - [Sakshi Singh](https://github.com/236sakshi)
 - [Sam Ruiz](https://github.com/LiebesleidSam)
 - [Samuel Maxey](https://github.com/SMAX-byte)
-- [Sanjeev]() Grabbing oppurtunities flawlessly
 - [Sashin Trout](https://github.com/sashin123)
 - [Sean Calderon](https://github.com/rimorgin)
 - [Shamir Ali](https://github.com/ShamirAli55)


### PR DESCRIPTION
Deleted user had no GitHub profile link mentioned and I tried to research similar users but none of them matched.
<img width="279" height="179" alt="image" src="https://github.com/user-attachments/assets/f1426ca7-e8c8-44fe-8fc0-f0a0532e6b2b" />
Kindly accept this Pull Request!
I really want to contribute in this project to enhance it and make it consistent. If you assign these tasks to me that would be great, just assign me or add me in this project or organization. This will be helpful for me to easily contribute and correct bugs and errors easily.
