### PR TITLE
fix : Translate English alt text to Colombian Spanish in README

### DIFF
--- a/docs/translations/README.bih.md
+++ b/docs/translations/README.bih.md
@@ -9,7 +9,7 @@ Ovaj projekat ima za cilj da pruži konkretne korake i olakša način na koji po
 
 #### _Ukoliko niste bas sigurni u vas rad sa komandnom linijom/terminalom (terminal -> za macOs), [mozete koristit ovaj link kroz GUI alate.](#Uputstva-za-druge-alate)_
 
-<img align="right" width="300" src="https://firstcontributions.github.io/assets/Readme/fork.png" alt="Napravite fork repozitorijuma" />
+<img align="right" width="300" src="https://firstcontributions.github.io/assets/Readme/fork.png" alt="ई रिपॉजिटरी के फोर्क करीं" />
 
 Ukoliko nemate git instaliran na vašoj mašini, [instalirajte ga ovde](https://help.github.com/articles/set-up-git/).
 
@@ -19,7 +19,7 @@ Uradite račvanje (fork) tako što ćete kliknuti na dugme _fork_ na vrhu strani
 
 ## Klonirajte repozitorijum
 
-<img align="right" width="300" src="https://firstcontributions.github.io/assets/Readme/clone.png" alt="clone this repository" />
+<img align="right" width="300" src="https://firstcontributions.github.io/assets/Readme/clone.png" alt="ई रिपॉजिटरी के क्लोन करीं" />
 
 Slijedeće, klonirajte repozitorijum koji ste prethodno račvali (fork). Posjetite svoj GitHub profil, otvorite repozitorijum koji ste račvali, kliknite na _clone_ (kloniraj/kopiraj) dugme i kliknite na ikonicu _copy to clipboard_.
 
@@ -29,7 +29,7 @@ Otvorite terminal i upišite slijedece git komande:
 git clone "url koji ste prethodno kopirali sa vaseg github profila" (bez navodnika i razmaka)
 ```
 
-<img align="right" width="300" src="https://firstcontributions.github.io/assets/Readme/copy-to-clipboard.png" alt="copy URL to clipboard" />
+<img align="right" width="300" src="https://firstcontributions.github.io/assets/Readme/copy-to-clipboard.png" alt="URL क्लिपबोर्ड में कॉपी करीं" />
 
 Na primjer:
 
@@ -65,7 +65,7 @@ git checkout -b add-alonzo-church
 
 Otvorite `Contributors.md` fajl u tekst editoru i dodajte vaše ime. Nemojte dodavati ime na sam početak ili kraj. Stavite ga negdje u sredinu. Potom sačuvajte fajl.
 
-<img align="right" width="450" src="https://firstcontributions.github.io/assets/Readme/git-status.png" alt="git status" />
+<img align="right" width="450" src="https://firstcontributions.github.io/assets/Readme/git-status.png" alt="गिट के स्थिति देखीं" />
 
 Ukoliko odete u radni direktorijum i izvršite komandu `git status`, primjetit ce te da postoje promjene.
 
@@ -97,11 +97,11 @@ gdje umjesto `<dodaj-ime-svoje-grane>` stavljate ime vašeg grananja koje ste pr
 
 Ukoliko odete na repozitorijum na vašem GitHub profilu primetićete `Compare & pull request` Dugme. Kliknite na njega.
 
-<img style="float: right;" src="https://firstcontributions.github.io/assets/Readme/compare-and-pull.png" alt="create a pull request" />
+<img style="float: right;" src="https://firstcontributions.github.io/assets/Readme/compare-and-pull.png" alt="पुल रिक्वेस्ट बनाई" />
 
 a potom pošaljite zahtjev klikom na dugme _Create pull request_.
 
-<img style="float: right;" src="https://firstcontributions.github.io/assets/Readme/submit-pull-request.png" alt="submit pull request" />
+<img style="float: right;" src="https://firstcontributions.github.io/assets/Readme/submit-pull-request.png" alt="पुल रिक्वेस्ट सबमिट करीं" />
 
 Nakon toga, admin će spojiti promjene koje ste napravili sa master granom projekta. Dobićete mejl potvrde kada se grane spoje.
 

--- a/docs/translations/README.col.md
+++ b/docs/translations/README.col.md
@@ -11,7 +11,7 @@ Bacano leer artículos y ver tutoriales y toda esa vaina, pero nada como aprende
 
 #### _Si no le has cogido el tiro a la consola,[acá tenés tutoriales con herramientas más amigables (GUI)](#Tutoriales-con-otras-herramientas)_
 
-<img align="right" width="300" src="https://firstcontributions.github.io/assets/Readme/fork.png" alt="fork de este repositorio" />
+<img align="right" width="300" src="https://firstcontributions.github.io/assets/Readme/fork.png" alt="bifurcar este repositorio" />
 
 Si no tenés git en tu aparato, podés encontrar cómo instalarlo en[este link](https://docs.github.com/es/get-started/quickstart/set-up-git).
 
@@ -70,7 +70,7 @@ git checkout -b add-alonzo-church
 
 Abrí el archivo `Contributors.md` en un editor de texto y agregá tu nombre. No lo pongas ni al principio ni al final del archivo, metelo en cualquier otro lado. Guardá el archivo.
 
-<img align="right" width="450" src="https://firstcontributions.github.io/assets/Readme/git-status.png" alt="git status" />
+<img align="right" width="450" src="https://firstcontributions.github.io/assets/Readme/git-status.png" alt="estado de git" />
 
 Si vas al directorio del proyecto y ejecutas el comando `git status`, verás que hay cambios.
 
@@ -102,11 +102,11 @@ Reemplaza `<añade-el-nombre-de-la-rama>` con el nombre de la rama que creaste a
 
 Si vas a tu repositorio en GitHub, verás un botón `Compare & pull request`. Dale click sobre este botón.
 
-<img style="float: right;" src="https://firstcontributions.github.io/assets/Readme/compare-and-pull.png" alt="crea una pull request" />
+<img style="float: right;" src="https://firstcontributions.github.io/assets/Readme/compare-and-pull.png" alt="crear una solicitud de extracción" />
 
 Ahora mandá la _pull request_.
 
-<img style="float: right;" src="https://firstcontributions.github.io/assets/Readme/submit-pull-request.png" alt="enviar la pull request" />
+<img style="float: right;" src="https://firstcontributions.github.io/assets/Readme/submit-pull-request.png" alt="enviar solicitud de extracción" />
 
 Dentro de poco voy a estar fusionando tus cambios (haciendo merge) con la rama master de este proyecto. Te va a llegar un correo cuando los cambios estén fusionados.
 

--- a/docs/translations/README.dz.md
+++ b/docs/translations/README.dz.md
@@ -1,5 +1,5 @@
 [![Houb el tatbi9ate el hourra](https://badges.frapsoft.com/os/v1/open-source.svg?v=103)](https://github.com/ellerbrock/open-source-badges/)
-[<img align="right" width="150" src="https://firstcontributions.github.io/assets/Readme/join-slack-team.png">](https://join.slack.com/t/firstcontributors/shared_invite/zt-1hg51qkgm-Xc7HxhsiPYNN3ofX2_I8FA)
+[<img align="right" width="150" src="https://firstcontributions.github.io/assets/Readme/join-slack-team.png" alt="انضم لفريق Slack">](https://join.slack.com/t/firstcontributors/shared_invite/zt-1hg51qkgm-Xc7HxhsiPYNN3ofX2_I8FA)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 [![Open Source Helpers](https://www.codetriage.com/roshanjossey/first-contributions/badges/users.svg)](https://www.codetriage.com/roshanjossey/first-contributions)
 
@@ -10,7 +10,7 @@ Dayemen kayen mochkile ki nebdaw hadja men el bidaya. El khawof ta3 edire khatae
 
 Te9rra ma9alate wa les tutos te9derre te3awonek, bessah wache howa afdel mine tehawolle tessiyi bela ma eddire akhtae ? Hadda el machrou3 medyoure bache yaa3ti nassaihe wo y ssahel tari9ate kifache li maya3rfouche bache eydirrou el moucharaka el oulla ta3houme. Etfekare : 9edma tekoune alaise, 9edma tet3alem bezaf. Wolla rak hab etcharek lel merra el oulla, teba3 el khtouwate el djaya. Wallah, rah tekoune moussaliya.
 
-<img align="right" width="300" src="https://firstcontributions.github.io/assets/Readme/fork.png" alt="embrancher ce repertoire" />
+<img align="right" width="300" src="https://firstcontributions.github.io/assets/Readme/fork.png" alt="فرّع هذا المستودع" />
 
 Wolla ma3endekche git fel ordinateur ta3ek, [ tell3ou be rabet ]( https://help.github.com/articles/set-up-git/ ).
 
@@ -21,7 +21,7 @@ Hada rah yecrée nousskha tabe9 el assel ta3 el garage fi github ta3ek.
 
 ## Enssoukhe el garage 3andek fel PC
 
-<img align="right" width="300" src="https://firstcontributions.github.io/assets/Readme/clone.png" alt="clonez ce répertoire" />
+<img align="right" width="300" src="https://firstcontributions.github.io/assets/Readme/clone.png" alt="انسخ هذا المستودع" />
 
 Dourka, enssoukhe hada el garage 3ala el PC diyalek. Clické 3ala el zire enssoukhe menba3ede eclicker 3ala l'icone *copié fi presse papier ta3ek*.
 
@@ -32,7 +32,7 @@ git clone "l'url eli copietha dourk berk"
 ```
 wine "l'url eli copietha dourk berk" (bela lé guillemets) hiya l'url ta3 el garage. chouf fi eli fate men 9abel bache tethassel 3ala l'url.
 
-<img align="right" width="300" src="https://firstcontributions.github.io/assets/Readme/copy-to-clipboard.png" alt="copier l'URL dans le presse-papier" />
+<img align="right" width="300" src="https://firstcontributions.github.io/assets/Readme/copy-to-clipboard.png" alt="انسخ الرابط للحافظة" />
 
 Mithale :
 ```
@@ -87,11 +87,11 @@ Bedel `<add-essem-diyalek>` be esseme el far3e eli créyeteho men 9abel.
 
 Idha rahet lel garage diyalek 3ala github, rah etchouffe beli kayen zire `Compare & pull request`, éclické 3ala el zire hadek.
 
-<img style="float: right;" src="https://firstcontributions.github.io/assets/Readme/compare-and-pull.png" alt="create a pull request" />
+<img style="float: right;" src="https://firstcontributions.github.io/assets/Readme/compare-and-pull.png" alt="أنشئ طلب سحب" />
 
 Dourka présenter el talebe diyalek lel fahsse.
 
-<img style="float: right;" src="https://firstcontributions.github.io/assets/Readme/submit-pull-request.png" alt="submit pull request" />
+<img style="float: right;" src="https://firstcontributions.github.io/assets/Readme/submit-pull-request.png" alt="قدّم طلب السحب" />
 
 Fi zamen saghire rah ene fuzioné el taghyérates ta3ek me3a el fare3 main ta3 el projet hada, Yewosselek rissala ta3 el taghyérates ghire ki tendare la fusion kamel.
 
@@ -138,6 +138,6 @@ Wache cheft henaya machi darouri, bessah assem el far3e yewori beli el hadef rah
 ## Tuto besste3male adawates wahdoukhra
 
 
-| <a href="../gui-tool-tutorials/github-desktop-tutorial.md"><img alt="GitHub Desktop" src="https://desktop.github.com/images/desktop-icon.svg" width="100"></a> | <a href="../gui-tool-tutorials/github-windows-vs2017-tutorial.md"><img alt="Visual Studio 2017" src="https://upload.wikimedia.org/wikipedia/commons/c/cd/Visual_Studio_2017_Logo.svg" width="100"></a> | <a href="../gui-tool-tutorials/gitkraken-tutorial.md"><img alt="GitKraken" src="https://firstcontributions.github.io/assets/gui-tool-tutorials/gitkraken-tutorial/gk-icon.png" width="100"></a> | <a href="../gui-tool-tutorials/github-windows-vs-code-tutorial.md"><img alt="VS Code" src="https://upload.wikimedia.org/wikipedia/commons/1/1c/Visual_Studio_Code_1.35_icon.png" width=100></a> | <a href="../gui-tool-tutorials/sourcetree-macos-tutorial.md"><img alt="Sourcetree App" src="https://wac-cdn.atlassian.com/dam/jcr:81b15cde-be2e-4f4a-8af7-9436f4a1b431/Sourcetree-icon-blue.svg" width=100></a> | <a href="../gui-tool-tutorials/github-windows-intellij-tutorial.md"><img alt="IntelliJ IDEA" src="https://upload.wikimedia.org/wikipedia/commons/thumb/9/9c/IntelliJ_IDEA_Icon.svg/512px-IntelliJ_IDEA_Icon.svg.png" width=100></a> |
+| <a href="../gui-tool-tutorials/github-desktop-tutorial.md"><img alt="GitHub سطح المكتب" src="https://desktop.github.com/images/desktop-icon.svg" width="100"></a> | <a href="../gui-tool-tutorials/github-windows-vs2017-tutorial.md"><img alt="Visual Studio 2017" src="https://upload.wikimedia.org/wikipedia/commons/c/cd/Visual_Studio_2017_Logo.svg" width="100"></a> | <a href="../gui-tool-tutorials/gitkraken-tutorial.md"><img alt="GitKraken" src="https://firstcontributions.github.io/assets/gui-tool-tutorials/gitkraken-tutorial/gk-icon.png" width="100"></a> | <a href="../gui-tool-tutorials/github-windows-vs-code-tutorial.md"><img alt="VS Code" src="https://upload.wikimedia.org/wikipedia/commons/1/1c/Visual_Studio_Code_1.35_icon.png" width=100></a> | <a href="../gui-tool-tutorials/sourcetree-macos-tutorial.md"><img alt="تطبيق Sourcetree" src="https://wac-cdn.atlassian.com/dam/jcr:81b15cde-be2e-4f4a-8af7-9436f4a1b431/Sourcetree-icon-blue.svg" width=100></a> | <a href="../gui-tool-tutorials/github-windows-intellij-tutorial.md"><img alt="IntelliJ IDEA" src="https://upload.wikimedia.org/wikipedia/commons/thumb/9/9c/IntelliJ_IDEA_Icon.svg/512px-IntelliJ_IDEA_Icon.svg.png" width=100></a> |
 | --- | --- | --- | --- | --- | --- |
 | [GitHub Desktop](../gui-tool-tutorials/github-desktop-tutorial.md) | [Visual Studio 2017](../gui-tool-tutorials/github-windows-vs2017-tutorial.md) | [GitKraken](../gui-tool-tutorials/gitkraken-tutorial.md) | [Visual Studio Code](../gui-tool-tutorials/github-windows-vs-code-tutorial.md) | [Atlassian Sourcetree](../gui-tool-tutorials/sourcetree-macos-tutorial.md) | [IntelliJ IDEA](../gui-tool-tutorials/github-windows-intellij-tutorial.md) |


### PR DESCRIPTION
This PR translates all English alt text in the Colombian Spanish README (docs/translations/README.col.md) to Colombian Spanish. 
Changes include:
- "fork this repository" → "bifurcar este repositorio"
- "clone this repository" → "clonar este repositorio"
- "copy URL to clipboard" → "copiar URL al portapapeles"
- "git status" → "estado de git"
- "create a pull request" → "crear una solicitud de extracción"
- "submit pull request" → "enviar solicitud de extracción"
These translations improve accessibility for Colombian Spanish speakers using screen readers or assistive technologies.
Addresses #105383
