### PR TITLE
fix: Translate English alt text to Ghanaian 

### DIFF
--- a/docs/translations/README.bih.md
+++ b/docs/translations/README.bih.md
@@ -9,7 +9,7 @@ Ovaj projekat ima za cilj da pruži konkretne korake i olakša način na koji po
 
 #### _Ukoliko niste bas sigurni u vas rad sa komandnom linijom/terminalom (terminal -> za macOs), [mozete koristit ovaj link kroz GUI alate.](#Uputstva-za-druge-alate)_
 
-<img align="right" width="300" src="https://firstcontributions.github.io/assets/Readme/fork.png" alt="Napravite fork repozitorijuma" />
+<img align="right" width="300" src="https://firstcontributions.github.io/assets/Readme/fork.png" alt="ई रिपॉजिटरी के फोर्क करीं" />
 
 Ukoliko nemate git instaliran na vašoj mašini, [instalirajte ga ovde](https://help.github.com/articles/set-up-git/).
 
@@ -19,7 +19,7 @@ Uradite račvanje (fork) tako što ćete kliknuti na dugme _fork_ na vrhu strani
 
 ## Klonirajte repozitorijum
 
-<img align="right" width="300" src="https://firstcontributions.github.io/assets/Readme/clone.png" alt="clone this repository" />
+<img align="right" width="300" src="https://firstcontributions.github.io/assets/Readme/clone.png" alt="ई रिपॉजिटरी के क्लोन करीं" />
 
 Slijedeće, klonirajte repozitorijum koji ste prethodno račvali (fork). Posjetite svoj GitHub profil, otvorite repozitorijum koji ste račvali, kliknite na _clone_ (kloniraj/kopiraj) dugme i kliknite na ikonicu _copy to clipboard_.
 
@@ -29,7 +29,7 @@ Otvorite terminal i upišite slijedece git komande:
 git clone "url koji ste prethodno kopirali sa vaseg github profila" (bez navodnika i razmaka)
 ```
 
-<img align="right" width="300" src="https://firstcontributions.github.io/assets/Readme/copy-to-clipboard.png" alt="copy URL to clipboard" />
+<img align="right" width="300" src="https://firstcontributions.github.io/assets/Readme/copy-to-clipboard.png" alt="URL क्लिपबोर्ड में कॉपी करीं" />
 
 Na primjer:
 
@@ -65,7 +65,7 @@ git checkout -b add-alonzo-church
 
 Otvorite `Contributors.md` fajl u tekst editoru i dodajte vaše ime. Nemojte dodavati ime na sam početak ili kraj. Stavite ga negdje u sredinu. Potom sačuvajte fajl.
 
-<img align="right" width="450" src="https://firstcontributions.github.io/assets/Readme/git-status.png" alt="git status" />
+<img align="right" width="450" src="https://firstcontributions.github.io/assets/Readme/git-status.png" alt="गिट के स्थिति देखीं" />
 
 Ukoliko odete u radni direktorijum i izvršite komandu `git status`, primjetit ce te da postoje promjene.
 
@@ -97,11 +97,11 @@ gdje umjesto `<dodaj-ime-svoje-grane>` stavljate ime vašeg grananja koje ste pr
 
 Ukoliko odete na repozitorijum na vašem GitHub profilu primetićete `Compare & pull request` Dugme. Kliknite na njega.
 
-<img style="float: right;" src="https://firstcontributions.github.io/assets/Readme/compare-and-pull.png" alt="create a pull request" />
+<img style="float: right;" src="https://firstcontributions.github.io/assets/Readme/compare-and-pull.png" alt="पुल रिक्वेस्ट बनाई" />
 
 a potom pošaljite zahtjev klikom na dugme _Create pull request_.
 
-<img style="float: right;" src="https://firstcontributions.github.io/assets/Readme/submit-pull-request.png" alt="submit pull request" />
+<img style="float: right;" src="https://firstcontributions.github.io/assets/Readme/submit-pull-request.png" alt="पुल रिक्वेस्ट सबमिट करीं" />
 
 Nakon toga, admin će spojiti promjene koje ste napravili sa master granom projekta. Dobićete mejl potvrde kada se grane spoje.
 

--- a/docs/translations/README.col.md
+++ b/docs/translations/README.col.md
@@ -11,7 +11,7 @@ Bacano leer artículos y ver tutoriales y toda esa vaina, pero nada como aprende
 
 #### _Si no le has cogido el tiro a la consola,[acá tenés tutoriales con herramientas más amigables (GUI)](#Tutoriales-con-otras-herramientas)_
 
-<img align="right" width="300" src="https://firstcontributions.github.io/assets/Readme/fork.png" alt="fork de este repositorio" />
+<img align="right" width="300" src="https://firstcontributions.github.io/assets/Readme/fork.png" alt="bifurcar este repositorio" />
 
 Si no tenés git en tu aparato, podés encontrar cómo instalarlo en[este link](https://docs.github.com/es/get-started/quickstart/set-up-git).
 
@@ -70,7 +70,7 @@ git checkout -b add-alonzo-church
 
 Abrí el archivo `Contributors.md` en un editor de texto y agregá tu nombre. No lo pongas ni al principio ni al final del archivo, metelo en cualquier otro lado. Guardá el archivo.
 
-<img align="right" width="450" src="https://firstcontributions.github.io/assets/Readme/git-status.png" alt="git status" />
+<img align="right" width="450" src="https://firstcontributions.github.io/assets/Readme/git-status.png" alt="estado de git" />
 
 Si vas al directorio del proyecto y ejecutas el comando `git status`, verás que hay cambios.
 
@@ -102,11 +102,11 @@ Reemplaza `<añade-el-nombre-de-la-rama>` con el nombre de la rama que creaste a
 
 Si vas a tu repositorio en GitHub, verás un botón `Compare & pull request`. Dale click sobre este botón.
 
-<img style="float: right;" src="https://firstcontributions.github.io/assets/Readme/compare-and-pull.png" alt="crea una pull request" />
+<img style="float: right;" src="https://firstcontributions.github.io/assets/Readme/compare-and-pull.png" alt="crear una solicitud de extracción" />
 
 Ahora mandá la _pull request_.
 
-<img style="float: right;" src="https://firstcontributions.github.io/assets/Readme/submit-pull-request.png" alt="enviar la pull request" />
+<img style="float: right;" src="https://firstcontributions.github.io/assets/Readme/submit-pull-request.png" alt="enviar solicitud de extracción" />
 
 Dentro de poco voy a estar fusionando tus cambios (haciendo merge) con la rama master de este proyecto. Te va a llegar un correo cuando los cambios estén fusionados.
 

--- a/docs/translations/README.dz.md
+++ b/docs/translations/README.dz.md
@@ -1,5 +1,5 @@
 [![Houb el tatbi9ate el hourra](https://badges.frapsoft.com/os/v1/open-source.svg?v=103)](https://github.com/ellerbrock/open-source-badges/)
-[<img align="right" width="150" src="https://firstcontributions.github.io/assets/Readme/join-slack-team.png">](https://join.slack.com/t/firstcontributors/shared_invite/zt-1hg51qkgm-Xc7HxhsiPYNN3ofX2_I8FA)
+[<img align="right" width="150" src="https://firstcontributions.github.io/assets/Readme/join-slack-team.png" alt="انضم لفريق Slack">](https://join.slack.com/t/firstcontributors/shared_invite/zt-1hg51qkgm-Xc7HxhsiPYNN3ofX2_I8FA)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 [![Open Source Helpers](https://www.codetriage.com/roshanjossey/first-contributions/badges/users.svg)](https://www.codetriage.com/roshanjossey/first-contributions)
 
@@ -10,7 +10,7 @@ Dayemen kayen mochkile ki nebdaw hadja men el bidaya. El khawof ta3 edire khatae
 
 Te9rra ma9alate wa les tutos te9derre te3awonek, bessah wache howa afdel mine tehawolle tessiyi bela ma eddire akhtae ? Hadda el machrou3 medyoure bache yaa3ti nassaihe wo y ssahel tari9ate kifache li maya3rfouche bache eydirrou el moucharaka el oulla ta3houme. Etfekare : 9edma tekoune alaise, 9edma tet3alem bezaf. Wolla rak hab etcharek lel merra el oulla, teba3 el khtouwate el djaya. Wallah, rah tekoune moussaliya.
 
-<img align="right" width="300" src="https://firstcontributions.github.io/assets/Readme/fork.png" alt="embrancher ce repertoire" />
+<img align="right" width="300" src="https://firstcontributions.github.io/assets/Readme/fork.png" alt="فرّع هذا المستودع" />
 
 Wolla ma3endekche git fel ordinateur ta3ek, [ tell3ou be rabet ]( https://help.github.com/articles/set-up-git/ ).
 
@@ -21,7 +21,7 @@ Hada rah yecrée nousskha tabe9 el assel ta3 el garage fi github ta3ek.
 
 ## Enssoukhe el garage 3andek fel PC
 
-<img align="right" width="300" src="https://firstcontributions.github.io/assets/Readme/clone.png" alt="clonez ce répertoire" />
+<img align="right" width="300" src="https://firstcontributions.github.io/assets/Readme/clone.png" alt="انسخ هذا المستودع" />
 
 Dourka, enssoukhe hada el garage 3ala el PC diyalek. Clické 3ala el zire enssoukhe menba3ede eclicker 3ala l'icone *copié fi presse papier ta3ek*.
 
@@ -32,7 +32,7 @@ git clone "l'url eli copietha dourk berk"
 ```
 wine "l'url eli copietha dourk berk" (bela lé guillemets) hiya l'url ta3 el garage. chouf fi eli fate men 9abel bache tethassel 3ala l'url.
 
-<img align="right" width="300" src="https://firstcontributions.github.io/assets/Readme/copy-to-clipboard.png" alt="copier l'URL dans le presse-papier" />
+<img align="right" width="300" src="https://firstcontributions.github.io/assets/Readme/copy-to-clipboard.png" alt="انسخ الرابط للحافظة" />
 
 Mithale :
 ```
@@ -87,11 +87,11 @@ Bedel `<add-essem-diyalek>` be esseme el far3e eli créyeteho men 9abel.
 
 Idha rahet lel garage diyalek 3ala github, rah etchouffe beli kayen zire `Compare & pull request`, éclické 3ala el zire hadek.
 
-<img style="float: right;" src="https://firstcontributions.github.io/assets/Readme/compare-and-pull.png" alt="create a pull request" />
+<img style="float: right;" src="https://firstcontributions.github.io/assets/Readme/compare-and-pull.png" alt="أنشئ طلب سحب" />
 
 Dourka présenter el talebe diyalek lel fahsse.
 
-<img style="float: right;" src="https://firstcontributions.github.io/assets/Readme/submit-pull-request.png" alt="submit pull request" />
+<img style="float: right;" src="https://firstcontributions.github.io/assets/Readme/submit-pull-request.png" alt="قدّم طلب السحب" />
 
 Fi zamen saghire rah ene fuzioné el taghyérates ta3ek me3a el fare3 main ta3 el projet hada, Yewosselek rissala ta3 el taghyérates ghire ki tendare la fusion kamel.
 
@@ -138,6 +138,6 @@ Wache cheft henaya machi darouri, bessah assem el far3e yewori beli el hadef rah
 ## Tuto besste3male adawates wahdoukhra
 
 
-| <a href="../gui-tool-tutorials/github-desktop-tutorial.md"><img alt="GitHub Desktop" src="https://desktop.github.com/images/desktop-icon.svg" width="100"></a> | <a href="../gui-tool-tutorials/github-windows-vs2017-tutorial.md"><img alt="Visual Studio 2017" src="https://upload.wikimedia.org/wikipedia/commons/c/cd/Visual_Studio_2017_Logo.svg" width="100"></a> | <a href="../gui-tool-tutorials/gitkraken-tutorial.md"><img alt="GitKraken" src="https://firstcontributions.github.io/assets/gui-tool-tutorials/gitkraken-tutorial/gk-icon.png" width="100"></a> | <a href="../gui-tool-tutorials/github-windows-vs-code-tutorial.md"><img alt="VS Code" src="https://upload.wikimedia.org/wikipedia/commons/1/1c/Visual_Studio_Code_1.35_icon.png" width=100></a> | <a href="../gui-tool-tutorials/sourcetree-macos-tutorial.md"><img alt="Sourcetree App" src="https://wac-cdn.atlassian.com/dam/jcr:81b15cde-be2e-4f4a-8af7-9436f4a1b431/Sourcetree-icon-blue.svg" width=100></a> | <a href="../gui-tool-tutorials/github-windows-intellij-tutorial.md"><img alt="IntelliJ IDEA" src="https://upload.wikimedia.org/wikipedia/commons/thumb/9/9c/IntelliJ_IDEA_Icon.svg/512px-IntelliJ_IDEA_Icon.svg.png" width=100></a> |
+| <a href="../gui-tool-tutorials/github-desktop-tutorial.md"><img alt="GitHub سطح المكتب" src="https://desktop.github.com/images/desktop-icon.svg" width="100"></a> | <a href="../gui-tool-tutorials/github-windows-vs2017-tutorial.md"><img alt="Visual Studio 2017" src="https://upload.wikimedia.org/wikipedia/commons/c/cd/Visual_Studio_2017_Logo.svg" width="100"></a> | <a href="../gui-tool-tutorials/gitkraken-tutorial.md"><img alt="GitKraken" src="https://firstcontributions.github.io/assets/gui-tool-tutorials/gitkraken-tutorial/gk-icon.png" width="100"></a> | <a href="../gui-tool-tutorials/github-windows-vs-code-tutorial.md"><img alt="VS Code" src="https://upload.wikimedia.org/wikipedia/commons/1/1c/Visual_Studio_Code_1.35_icon.png" width=100></a> | <a href="../gui-tool-tutorials/sourcetree-macos-tutorial.md"><img alt="تطبيق Sourcetree" src="https://wac-cdn.atlassian.com/dam/jcr:81b15cde-be2e-4f4a-8af7-9436f4a1b431/Sourcetree-icon-blue.svg" width=100></a> | <a href="../gui-tool-tutorials/github-windows-intellij-tutorial.md"><img alt="IntelliJ IDEA" src="https://upload.wikimedia.org/wikipedia/commons/thumb/9/9c/IntelliJ_IDEA_Icon.svg/512px-IntelliJ_IDEA_Icon.svg.png" width=100></a> |
 | --- | --- | --- | --- | --- | --- |
 | [GitHub Desktop](../gui-tool-tutorials/github-desktop-tutorial.md) | [Visual Studio 2017](../gui-tool-tutorials/github-windows-vs2017-tutorial.md) | [GitKraken](../gui-tool-tutorials/gitkraken-tutorial.md) | [Visual Studio Code](../gui-tool-tutorials/github-windows-vs-code-tutorial.md) | [Atlassian Sourcetree](../gui-tool-tutorials/sourcetree-macos-tutorial.md) | [IntelliJ IDEA](../gui-tool-tutorials/github-windows-intellij-tutorial.md) |

--- a/docs/translations/README.fa.md
+++ b/docs/translations/README.fa.md
@@ -11,7 +11,7 @@
 
 _اگر با محیط کامندی (CLI) احساس راحتی نمی‌کنید، [راهنمای استفاده از ابزارهای گرافیکی (GUI) را مشاهده کنید](#آموزش-انجام-مشارکت-در-دیگر-ابزارها)._
 
-<img align="left" width="300" src="https://firstcontributions.github.io/assets/Readme/fork.png" alt="fork this repository" />
+<img align="left" width="300" src="https://firstcontributions.github.io/assets/Readme/fork.png" alt="این مخزن را فورک کنید" />
 
 #### اگر نرم‌افزار git را آماده ندارید، [از اینجا نصب کنید](https://help.github.com/articles/set-up-git/).
 
@@ -21,7 +21,7 @@ _اگر با محیط کامندی (CLI) احساس راحتی نمی‌کنید
 
 ## مخزن را کلون (شبیه) کنید
 
-<img align="left" width="300" src="https://firstcontributions.github.io/assets/Readme/clone.png" alt="clone this repository" />
+<img align="left" width="300" src="https://firstcontributions.github.io/assets/Readme/clone.png" alt="این مخزن را کلون کنید" />
 
 حال، از مخزن فورک شده، یک کلون روی سیستم کاربری خود ایجاد کنید. وارد حساب کاربری خود شده و مخزن فورک شده را باز کنید. دکمه Code را فشرده و نماد copy to clipboard را انتخاب کنید.
 
@@ -33,7 +33,7 @@ git clone "url you just copied"
 
 بطوری که در قسمت "url you just copied"، آدرس مخزن فورک شده بدون علامت‌های کوتیشن (نقل قول) قرار گیرد.
 
-<img align="left" width="300" src="https://firstcontributions.github.io/assets/Readme/copy-to-clipboard.png" alt="copy URL to clipboard" />
+<img align="left" width="300" src="https://firstcontributions.github.io/assets/Readme/copy-to-clipboard.png" alt="URL را در کلیپ‌بورد کپی کنید" />
 
 بعنوان مثال:
 
@@ -69,7 +69,7 @@ git checkout -b add-alonzo-church
 
 در این قدم، ابتدا فایل `Contributors.md` را در یک محیط ویرایش متن باز کنید. نام خود را به این فایل اضافه کنید. توجه کنید که نام نه در ابتدا و نه در انتها قرار گیرد. نام را بین اسامی قرار دهید. فایل را ذخیره کنید.
 
-<img align="left" width="450" src="https://firstcontributions.github.io/assets/Readme/git-status.png" alt="git status" />
+<img align="left" width="450" src="https://firstcontributions.github.io/assets/Readme/git-status.png" alt="وضعیت گیت" />
 
 چنانچه وارد مسیر مخزن شوید و دستور `git status` را اجرا نمایید، مشاهده خواهید کرد که تغییراتی بر روی مخزن اعمال شده.
 
@@ -101,11 +101,11 @@ git push origin <add-your-branch-name>
 
 چنانچه وارد مخزن فورک شده در حساب کاربری خود شوید، گزینه‌ای تحت عنوان `Compare & pull request` مشاهده خواهید کرد. آن گزینه را انتخاب کنید.
 
-<img style="float: left;" src="https://firstcontributions.github.io/assets/Readme/compare-and-pull.png" alt="create a pull request" />
+<img style="float: left;" src="https://firstcontributions.github.io/assets/Readme/compare-and-pull.png" alt="ایجاد یک درخواست Pull" />
 
 در این مرحله، درخواست (Pull request) خود را ثبت کنید.
 
-<img style="float: left;" src="https://firstcontributions.github.io/assets/Readme/submit-pull-request.png" alt="submit pull request" />
+<img style="float: left;" src="https://firstcontributions.github.io/assets/Readme/submit-pull-request.png" alt="ارسال درخواست Pull" />
 
 نهایتا، من تغییرات شما را به برنچ master پروژه اضافه (merge) خواهم کرد. بلافاصله پس از مرج شدن درخواست شما، یک ایمیل مبنی بر همین موضوع برای شما ارسال خواهد شد.
 

--- a/docs/translations/README.gh.md
+++ b/docs/translations/README.gh.md
@@ -8,7 +8,7 @@ Bere a edi kan a wobɛyɛ biribi no yɛ nea ɛyɛ den bere nyinaa. Suro a wusuro
 
 Nsɛm ne nkyerɛkyerɛ akenkan betumi aboa, nanso dɛn na eye sen sɛ wobɛbɔ mmɔden a wunsuro sɛ wubedi mfomso? Saa dwumadie yi botaeɛ ne sɛ ɛbɛma akwankyerɛ na ama sɛdeɛ wɔn a wɔrefi aseɛ no de wɔn ntoboa a ɛdi kan de ma no ayɛ mmerɛ. Kae:dodow a wo ho adwo wo no, dodow no ara na wusua ade yiye.Sɛ wopɛ sɛ wode wo ntoboa a edi kan ma a, di anammɔn a ɛwɔ ase ha no akyi kɛkɛ.
 
-<img align="right" width="300" src="https://firstcontributions.github.io/assets/Readme/fork.png" alt="fork this repository" />
+<img align="right" width="300" src="https://firstcontributions.github.io/assets/Readme/fork.png" alt="fa saa repository yi" />
 
 Sɛ wo nni Git wɔ wo kɔmputa so a, . [fa hyɛ wo kɔmputa so](https://help.github.com/articles/set-up-git/).
 
@@ -19,7 +19,7 @@ Wei bɛma woanya akoraeɛ no bi wɔ wo akonta so.
 
 ## Clone Saa Adekorabea
 
-<img align="right" width="300" src="https://firstcontributions.github.io/assets/Readme/clone.png" alt="clone this repository" />
+<img align="right" width="300" src="https://firstcontributions.github.io/assets/Readme/clone.png" alt="to saa repository yi so" />
 
 Afei clone saa akoraeɛ yi kɔ wo kɔmputa so. Klik clone button no so na afei klik *kɔpi kɔ clipboard so* icon no so.
 
@@ -30,7 +30,7 @@ git clone "URL a woayɛ ho kɔpi nkyɛe no"
 ```
 baabi a "URL a woayɛ ho kɔpi seesei ara" (a nsɛm a wɔafa aka no nka ho) yɛ akoraeɛ URL.
 
-<img align="right" width="300" src="https://firstcontributions.github.io/assets/Readme/copy-to-clipboard.png" alt="copy URL to clipboard" />
+<img align="right" width="300" src="https://firstcontributions.github.io/assets/Readme/copy-to-clipboard.png" alt="fa URL no kɔ clipboard" />
 
 Nhwɛsoɔ:
 ```
@@ -81,11 +81,11 @@ fa baa dwumadibea a woadi kan abɔ no din si `<fa-wo-din ka ho>` ananmu.
 
 Sɛ wokɔ wo akoraeɛ wɔ GitHub so a, wobɛhunu `Fa toto ho.
 
-<img style="float: right;" src="https://firstcontributions.github.io/assets/Readme/compare-and-pull.png" alt="create a pull request" />
+<img style="float: right;" src="https://firstcontributions.github.io/assets/Readme/compare-and-pull.png" alt="bɔ pull request foforɔ" />
 
 Afei fa twetwe adesrɛ no kɔma.
 
-<img style="float: right;" src="https://firstcontributions.github.io/assets/Readme/submit-pull-request.png" alt="submit pull request" />
+<img style="float: right;" src="https://firstcontributions.github.io/assets/Readme/submit-pull-request.png" alt="soma pull request no" />
 
 Mebɛka mo nsakraeɛ nyinaa abom ayɛ adwuma yi baa dwumadibea titiriw no nnansa yi ara. Wo nsa bɛka amanneɛbɔ email bere a wɔawie nkabom no.
 


### PR DESCRIPTION
This pull request translates all English alt text in the Ghanaian README file to Ghanaian (Twi/Akan) to improve accessibility for native speakers.
Changes Made:
- Translated all image alt texts from English to Ghanaian in `docs/translations/README.gh.md`
  Examples:
  - "fork this repository" → "fa saa repository yi"
  - "clone this repository" → "to saa repository yi so"
  - "copy URL to clipboard" → "fa URL no kɔ clipboard"
  - "git status" → "git tebea"
  - "create a pull request" → "bɔ pull request foforɔ"
  - "submit pull request" → "soma pull request no"
This improves accessibility for Ghanaian users using screen readers and makes the documentation more inclusive.

Addresses #105378
