### PR TITLE
Update security policy with vulnerability reporting instructions

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -2,6 +2,6 @@
 
 ## Reporting a Vulnerability
 
-In order for the vulnerability reports to reach maintainers as soon as possible, the preferred way is to use the "Report a vulnerability" button under the "Security" tab of the associated GitHub project. This creates a private communication channel between the reporter and the maintainers.
+In order for vulnerability reports to reach maintainers as soon as possible, the preferred method is to use the "Report a vulnerability" button under the "Security" tab of the associated GitHub project. This creates a private communication channel between the reporter and the maintainers.
 
-If you are absolutely unable to or have strong reasons not to use GitHub's vulnerability reporting workflow, please reach out to the the team by mailing to firstcontributions@gmail.com
+If you cannot or prefer not to use GitHub's vulnerability reporting workflow, please reach out to the team by emailing firstcontributions@gmail.com.


### PR DESCRIPTION
Added a Security Policy section to improve how vulnerability reports should be submitted.

- Recommended using GitHub’s “Report a vulnerability” button for private communication.
- Provided an email fallback for reporting vulnerabilities.

- [x] I had fun going through this tutorial (ノ^o^)ノ and learned on the way ٩(＾◡＾)۶
- [ ] There are some things I'd like to improve in this tutorial. I have written them below.
- [ ] There were steps where I had errors while following this tutorial. I have written them below.
