### PR TITLE
Added bash syntax specs to Afrikaans README code blocks #105990

### DIFF
--- a/docs/translations/README.afk.md
+++ b/docs/translations/README.afk.md
@@ -28,7 +28,7 @@ Klone nou die vurk repo aan jou masjien. Gaan na jou GitHub-rekening, maak die v
 
 Open 'n terminaal en voer die volgende git opdrag uit:
 
-```
+```bash
 git clone "url you just copied"
 ```
 
@@ -38,7 +38,7 @@ waar "url jy net gekopieer" het (sonder die aanhalingstekens) is die url na hier
 
 Byvoorbeeld:
 
-```
+```bash
 git clone https://github.com/this-is-you/first-contributions.git
 ```
 
@@ -48,19 +48,19 @@ waar `this-is-you` jou GitHub gebruikersnaam is. Hier kopieer jy die inhoud van 
 
 Verander na die repository gids op jou rekenaar (as jy nie reeds daar is nie):
 
-```
+```bash
 cd first-contributions
 ```
 
 Skep nou 'n tak met die git `checkout` opdrag:
 
-```
+```bash
 git checkout -b <add-your-new-branch-name>
 ```
 
 Byvoorbeeld:
 
-```
+```bash
 git checkout -b add-alonzo-church
 ```
 
@@ -77,13 +77,13 @@ As u na die projekgids gaan en die opdrag uitvoer `git status`, sal u sien dat d
 
 Voeg die veranderinge by die tak wat jy net geskep het deur die `git add` opdrag te gebruik:
 
-```
+```bash
 git add Contributors.md
 ```
 
 Doen nou die veranderinge deur die `git commit` opdrag te gebruik:
 
-```
+```bash
 git commit -m "Add <your-name> to Contributors list"
 ```
 
@@ -93,7 +93,7 @@ vervang `<your-name>` met jou naam.
 
 Druk jou veranderinge deur die opdrag te gebruik `git push`:
 
-```
+```bash
 git push origin <add-your-branch-name>
 ```
 


### PR DESCRIPTION
- Problem
The Afrikaans translation has code blocks without language specifications (just `instead of` bash), which prevents proper syntax highlighting and makes the commands less readable

- Solution
Added bash language tag to all shell command code blocks in docs/translations/README.afk.md.
Improved readability and syntax highlighting in the Afrikaans README.

Addresses #105990
