### PR TITLE
Added bash syntax specs to Mongolian README code blocks #105978

### DIFF
--- a/docs/translations/README.mn.md
+++ b/docs/translations/README.mn.md
@@ -29,10 +29,8 @@
 
 Терминал нээгээд дараах командыг ажиллуулна:  
 
-```
-
+```bash
 git clone "та хуулсан url"
-
 ```
 
 Энд `"та хуулсан url"` гэдэг нь энэ төслийн таны салаалсан хувилбарын URL юм.  
@@ -41,10 +39,8 @@ git clone "та хуулсан url"
 
 Жишээ нь:  
 
-```
-
+```bash
 git clone [https://github.com/taniin-ner/first-contributions.git](https://github.com/taniin-ner/first-contributions.git)
-
 ```
 
 Энд `taniin-ner` гэдэг нь таны GitHub-н хэрэглэгчийн нэр.  
@@ -53,26 +49,20 @@ git clone [https://github.com/taniin-ner/first-contributions.git](https://github
 
 Компьютер дээрээ тухайн репо руу орно:  
 
-```
-
+```bash
 cd first-contributions
-
 ```
 
 Шинэ салбар үүсгэнэ:  
 
-```
-
+```bash
 git checkout -b <shine-salbar-ner>
-
 ```
 
 Жишээ нь:  
 
-```
-
+```bash
 git checkout -b add-luke-oliff
-
 ```
 
 (*Салбарын нэр заавал `add` гэж эхлэх албагүй, гэхдээ өөрийн нэрээ нэмэх зорилготой тул ингэж нэрлэх нь ойлгомжтой.*)
@@ -87,28 +77,22 @@ git checkout -b add-luke-oliff
 
 Өөрчлөлтөө салбартаа нэмнэ:  
 
-```
-
+```bash
 git add Contributors.md
-
 ```
 
 Commit хийж хадгална:  
 
-```
-
+```bash
 git commit -m "Add <tanii-ner> to Contributors list"
-
 ```
 
 ## Өөрчлөлтөө GitHub руу push хийх
 
 Дараах командаар өөрчлөлтөө push хийнэ:  
 
-```
-
+```bash
 git push origin <salbar-ner>
-
 ```
 
 `<salbar-ner>` хэсэгт та өмнө үүсгэсэн салбарын нэрээ оруулна.  
@@ -140,8 +124,6 @@ GitHub дээр өөрийн репод ормогцоо **Compare & pull reques
 | <a href="../gui-tool-tutorials/github-desktop-tutorial.md"><img alt="GitHub Desktop" src="https://desktop.github.com/images/desktop-icon.svg" width="100"></a> | <a href="../gui-tool-tutorials/github-windows-vs2017-tutorial.md"><img alt="Visual Studio 2017" src="https://upload.wikimedia.org/wikipedia/commons/c/cd/Visual_Studio_2017_Logo.svg" width="100"></a> | <a href="../gui-tool-tutorials/gitkraken-tutorial.md"><img alt="GitKraken" src="https://firstcontributions.github.io/assets/gui-tool-tutorials/gitkraken-tutorial/gk-icon.png" width="100"></a> | <a href="../gui-tool-tutorials/github-windows-vs-code-tutorial.md"><img alt="VS Code" src="https://upload.wikimedia.org/wikipedia/commons/1/1c/Visual_Studio_Code_1.35_icon.png" width=100></a> | <a href="../gui-tool-tutorials/sourcetree-macos-tutorial.md"><img alt="Sourcetree App" src="https://wac-cdn.atlassian.com/dam/jcr:81b15cde-be2e-4f4a-8af7-9436f4a1b431/Sourcetree-icon-blue.svg" width=100></a> | <a href="../gui-tool-tutorials/github-windows-intellij-tutorial.md"><img alt="IntelliJ IDEA" src="https://upload.wikimedia.org/wikipedia/commons/thumb/9/9c/IntelliJ_IDEA_Icon.svg/512px-IntelliJ_IDEA_Icon.svg.png" width=100></a> |
 | --- | --- | --- | --- | --- | --- |
 | [GitHub Desktop](../gui-tool-tutorials/github-desktop-tutorial.md) | [Visual Studio 2017](../gui-tool-tutorials/github-windows-vs2017-tutorial.md) | [GitKraken](../gui-tool-tutorials/gitkraken-tutorial.md) | [Visual Studio Code](../gui-tool-tutorials/github-windows-vs-code-tutorial.md) | [Atlassian Sourcetree](../gui-tool-tutorials/sourcetree-macos-tutorial.md) | [IntelliJ IDEA](../gui-tool-tutorials/github-windows-intellij-tutorial.md) |
-```
 
----
 
 


### PR DESCRIPTION
- Problem
The Mongolian translation has code blocks without language specifications (just `instead of` bash), which prevents proper syntax highlighting and makes the commands less readable.

- Solution
Added bash language tag to all shell command code blocks in docs/translations/README.mn.md.
Improved readability and syntax highlighting in the Mongolian README.

Resolves #105978 