### PR TITLE
Fix broken translation links in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -10,78 +10,78 @@ If you're making changes to a translation, please request a review from our prev
 
 | Language Name | Name in English | Reviewers|
 |---|---|---|
-| Afrikaans | [Afrikaans](../main/docs/translations/README.afk.md) | [<img width="100" src="https://avatars.githubusercontent.com/u/36197725?v=4" alt="@zecollokaris" />](https://github.com/zecollokaris) |
-| Albanian | [Albanian](../main/docs/translations/README.al.md) | [<img width="100" src="https://avatars.githubusercontent.com/u/40631828?v=4" alt="RronKurtishi" />](https://github.com/RronKurtishi) [<img width="100" src="https://avatars.githubusercontent.com/u/98396887?s=400&v=4" alt="RronKurtishi" />](https://github.com/auronvila) |
-| العربية | [Arabic](../main/docs/translations/README.ar.md) | [<img width="100" src="https://avatars.githubusercontent.com/u/83532081?v=4" alt="OsaidAlhomedy" />](https://github.com/OsaidAlhomedy) [<img width="100" src="https://avatars.githubusercontent.com/u/97640062?v=4" alt="AlaaYlula" />](https://github.com/AlaaYlula) [<img width="100" src="https://avatars.githubusercontent.com/u/60319236?v=4" alt="Laith-Alayassa" />](https://github.com/Laith-Alayassa) |
-| Azerbaijani | [Azerbaijani](../main/docs/translations/README.aze.md) | [<img width="100" src="https://avatars.githubusercontent.com/u/60487349?v=4" alt="@isakurbanov744" />](https://github.com/isakurbanov744)   [<img width="100" src="https://avatars.githubusercontent.com/u/58222828?v=4" alt="@Ahm3tJ4f" />](https://github.com/Ahm3tJ4f) |
-| Bulgarian | [Bulgarian](../main/docs/translations/README.bg.md) | []() |
-| Bosnian | [Bosnian](../main/docs/translations/README.bih.md) | []() |
-| বাংলা | [Bengali](../main/docs/translations/README.bn.md) | [<img width="100" src="https://avatars3.githubusercontent.com/u/12910423?s=460&v=4" alt="@cse031sust02" />](https://github.com/cse031sust02) |
-| Belarusian | [Belarusian](../main/docs/translations/README.by.md) | []() |
-| Català | [Catalan](../main/docs/translations/README.ca.md) | [<img width="100" src="https://avatars0.githubusercontent.com/u/16263046?s=460&v=4" alt="@Sergih28" />](https://github.com/Sergih28) |
-| čeština | [Czech](../main/docs/translations/README.cs.md) | []() |
-| Danish | [Danish](../main/docs/translations/README.da.md) | [<img width="100" src="https://avatars1.githubusercontent.com/u/15271858?s=460&v=4" alt="@7013145" />](https://github.com/7013145) |
-| Deutsch | [German](../main/docs/translations/README.de.md) | [<img width="100" src="https://avatars3.githubusercontent.com/u/22977266?s=460&v=4" alt="@lkreimann" />](https://github.com/lkreimann) |
-| المصرية | [Egyptian](../main/docs/translations/README.eg.md) | [<img width="100" src="https://avatars0.githubusercontent.com/u/12827629?s=460&v=4" alt="@MichaelKMalak" />](https://github.com/MichaelKMalak) |
-| English (Pirate) | [English (Pirate)](../main/docs/translations/README.en-pirate.md) | [<img width="100" src="https://avatars0.githubusercontent.com/u/956290?s=460&v=4" alt="@lukeoliff" />](https://github.com/lukeoliff) |
-| Español | [Spanish](../main/docs/translations/README.es.md) | [<img width="100" src="https://avatars3.githubusercontent.com/u/16923944?s=460&v=4" alt="@yirini" />](https://github.com/yirini) [<img width="100" src="https://avatars.githubusercontent.com/u/10425834?v=4" alt="@aaossa" />](https://github.com/aaossa) |
-| فارسی | [Persian](../main/docs/translations/README.fa.md) | [<img width="100" src="https://avatars2.githubusercontent.com/u/20030805?s=460&v=4" alt="@ThirdScript" />](https://github.com/ThirdScript) |
-| Finnish | [Finnish](../main/docs/translations/README.fi.md) | []() |
-| Français | [French](../main/docs/translations/README.fr.md) | [<img width="100" src="https://avatars0.githubusercontent.com/u/13402464?s=460&v=4" alt="@LePetitRenard" />](https://github.com/LePetitRenard) |
-| ქართული | [Georgian](../main/docs/translations/README.ka.md) | [<img width="100" src="https://avatars0.githubusercontent.com/u/9116447?s=460&v=4" alt="@iko1133" />](https://github.com/iko1133) |
-| Galego | [Galician](../main/docs/translations/README.gl.md) | [<img width="100" src="https://avatars1.githubusercontent.com/u/16878891?s=460&v=4" alt="@siderio2" />](https://github.com/siderio2) |
-| Greek | [Greek](../main/docs/translations/README.gr.md) |  [<img width="100" src="https://avatars.githubusercontent.com/u/63111742?v=4" alt="@adreaskar" />](https://github.com/adreaskar)   [<img width="100" src="https://avatars.githubusercontent.com/u/19299306?v=4" alt="@porfanid" />](https://github.com/porfanid)  |
-| ગુજરાતી | [Gujarati](../main/docs/translations/README.guj.md) | [<img width="100" src="https://avatars2.githubusercontent.com/u/38134283?s=460&v=4" alt="@smitgajjar" />](https://github.com/smitgajjar) [<img width="100" src="https://avatars.githubusercontent.com/u/16669911?v=4" alt="@kaushalgosaliya5" />](https://github.com/kaushalgosaliya5/) |
-| Hausa | [Hausa](../main/docs/translations/README.hau.md) | []() |
-| עברית | [Hebrew](../main/docs/translations/README.hb.md) | [<img width="100" src="https://avatars1.githubusercontent.com/u/23402988?s=460&v=4" alt="@TomerPacific" />](https://github.com/TomerPacific) |
-| हिन्दी | [Hindi](../main/docs/translations/README.hi.md) | [<img width="100" src="https://avatars2.githubusercontent.com/u/4654382?s=460&v=4" alt="@arshadkazmi42" />](https://github.com/arshadkazmi42) [<img width="100" src="https://avatars2.githubusercontent.com/u/7047079?s=460&v=4" alt="@sara-02" />](https://github.com/sara-02) [<img width="100" src="https://avatars.githubusercontent.com/u/20799404?v=4" alt="shrut1996" />](https://github.com/shrut1996) |
-| Chhattisgarhi | [Chhattisgarhi](../main/docs/translations/README.hne.md) | [<img width="100" src="https://avatars2.githubusercontent.com/u/54806739?s=400&v=4" alt="@pradyyadav" />](https://github.com/pradyyadav) |
-| Magyar | [Hungarian](../main/docs/translations/README.hu.md) | []() |
-| Armenian | [Armenian](../main/docs/translations/README.hy.md) | []() |
-| Indonesian | [Indonesian](../main/docs/translations/README.id.md) | [<img width="100" src="https://avatars0.githubusercontent.com/u/315048?s=460&v=4" alt="@hahn" />](https://github.com/hahn) |
-| Igbo | [Igbo](../main/docs/translations/README.igb.md) | [<img width="100" src="https://avatars.githubusercontent.com/u/36197725?v=4" alt="@zecollokaris" />](https://github.com/zecollokaris) []() |
-| Italiano | [Italian](../main/docs/translations/README.it.md) | [<img width="100" src="https://avatars0.githubusercontent.com/u/22260641?s=460&v=4" alt="@platipo" />](https://github.com/platipo) |
-| 日本語 | [Japanese](../main/docs/translations/README.ja.md) | [<img width="100" src="https://avatars3.githubusercontent.com/u/12928246?s=460&v=4" alt="@cbondurant" />](https://github.com/cbondurant) |
-| ಕನ್ನಡ | [Kannada](../main/docs/translations/README.ka.md) | []() |
-| 한국어 | [Korean](../main/docs/translations/README.ko.md) | [<img width="100" src="https://avatars0.githubusercontent.com/u/2732120?s=460&v=4" alt="@espozbob" />](https://github.com/espozbob) |
-| Kiswahili | [Kiswahili](../main/docs/translations/README.kws.md) |[<img width="100" src="https://avatars.githubusercontent.com/u/36197725?v=4" alt="@zecollokaris" />](https://github.com/zecollokaris)  []() |
-| Kazakh | [Kazakh](../main/docs/translations/README.kz.md) | [<img width="100" src="https://avatars3.githubusercontent.com/u/12928246?s=460&v=4" alt="@kurshakuz" />](https://github.com/kurshakuz) |
-| Lietuvių kalba | [Lithuanian](../main/docs/translations/README.lt.md) | [<img width="100" src="https://avatars1.githubusercontent.com/u/9092712?s=460&v=4" alt="@neone35" />](https://github.com/neone35) |
-| Latviešu valoda | [Latvian](../main/docs/translations/README.lv.md) | []() |
-|  | [me](../main/docs/translations/README.me.md) | [<img width="100" src="https://avatars1.githubusercontent.com/u/9092712?s=460&v=4" alt="@neone35">]() |
-| Македонски | [Macedonian](../main/docs/translations/README.mk.md) | []() |
-| മലയാളം | [Malayalam](../main/docs/translations/README.ml.md) | [<img width="100" src="https://avatars.githubusercontent.com/u/3657426?v=4" alt="@yedhukrishnan">](https://github.com/yedhukrishnan) |
-| Burmese | [Burmese](../main/docs/translations/README.mm_unicode.md) | [<img width="100" src="https://avatars0.githubusercontent.com/u/13135332?s=460&v=4" alt="@lwinkyawmyat" />](https://github.com/lwinkyawmyat) |
-| मराठी | [Marathi](../main/docs/translations/README.mr.md) | [<img width="100" src="https://avatars1.githubusercontent.com/u/16685565?s=460&v=4" alt="@bantya" />](https://github.com/bantya) |
-| Español de México | [Spanish of Mexico](../main/docs/translations/README.mx.md) | []() |
-| Bahasa Melayu | [Malay](../main/docs/translations/README.my.md) | []() |
-| Nederlandse | [Dutch](../main/docs/translations/README.nl.md) | [<img width="100" src="https://avatars0.githubusercontent.com/u/3897815?s=460&v=4" alt="@MJMajoor" />](https://github.com/MJMajoor) |
-| Norsk | [Norwegian](../main/docs/translations/README.no.md) | [<img width="100" src="https://avatars.githubusercontent.com/u/75746434?s=400&u=0a0854f15eb1f7fd5169d108bb1f12f875c172c6&v=4" alt="Islandstone89 on Github" />](https://github.com/Islandstone89) |
-| नेपाली | [Nepali](../main/docs/translations/README.np.md) | [<img width="100" src="https://avatars2.githubusercontent.com/u/2145263?s=460&v=4" alt="@milap-neupane" />](https://github.com/milap-neupane) |
-| ਪੰਜਾਬੀ | [Punjabi](../main/docs/translations/README.pb.md) | []() |
-| Polski | [Polish](../main/docs/translations/README.pl.md) | [<img width="100" src="https://avatars0.githubusercontent.com/u/3372341?s=460&v=4" alt="@P1X3L0V4" />](https://github.com/P1X3L0V4) [<img width="100" src="https://avatars2.githubusercontent.com/u/1311358?v=4" alt="@mikowhy" />](https://github.com/mikowhy) |
-| Português | [Portugues (Portugal)](../main/docs/translations/README.pt-pt.md) | [<img width="100" src="https://avatars.githubusercontent.com/u/36346554?v=4" alt="@RamosCSV" />](https://github.com/RamosCSV) |
-| Português do Brasil | [Portugues (Brazil)](../main/docs/translations/README.pt_br.md) | [<img width="100" src="https://avatars2.githubusercontent.com/u/10578275?s=460&v=4" alt="@OtacilioN" />](https://github.com/OtacilioN) [<img width="100" src="https://avatars2.githubusercontent.com/u/47339825?s=460&v=4" alt="@gabrielsanttana" />](https://github.com/gabrielsanttana)|
-| Română | [Romanian](../main/docs/translations/README.ro.md) | [ <img width="100" src="https://avatars2.githubusercontent.com/u/20670448?s=460&v=4" alt="@dp97" />](https://github.com/dp97) |
-| Русский | [Russian](../main/docs/translations/README.ru.md) | [<img width="100" src="https://avatars2.githubusercontent.com/u/4745723?s=460&v=4" alt="@ayanovsk" />](https://github.com/ayanovsk) |
-| Svenska | [Swedish](../main/docs/translations/README.se.md) | [<img width="100" src="https://avatars0.githubusercontent.com/u/2447741?s=460&v=4" alt="@jcer" />](https://github.com/jcer) |
-| Sinhala | [Sinhala](../main/docs/translations/README.si.md) | []() |
-| Sindhi | [Sindhi](../main/docs/translations/README.sindhi.md) | []() |
-| Slovenčina | [Slovak](../main/docs/translations/README.sk.md) | [<img width="100" src="https://avatars3.githubusercontent.com/u/16558136?s=460&v=4" alt="@CoderKlemen" />](https://github.com/CoderKlemen) |
-| Slovenščina | [Slovenian](../main/docs/translations/README.slk.md) | [<img width="100" src="https://avatars0.githubusercontent.com/u/11976353?s=460&v=4" alt="@hercegtomas" />](https://github.com/hercegtomas) |
-| Српски | [Serbian (Cyrillic)](../main/docs/translations/README.sr-Cyrl.md) | [<img width="100" src="https://avatars.githubusercontent.com/u/40705899?v=4" alt="@rammba" />](https://github.com/rammba) |
-| Srpski | [Serbian (Latin)](../main/docs/translations/README.sr-Latn.md) | [<img width="100" src="https://avatars.githubusercontent.com/u/35745051?v=4" alt="@Mateja3m" />](https://github.com/Mateja3m) [<img width="100" src="https://avatars.githubusercontent.com/u/40705899?v=4" alt="@rammba" />](https://github.com/rammba) |
-| தமிழ் | [Tamil](../main/docs/translations/README.ta.md) | [<img width="100" src="https://avatars.githubusercontent.com/u/7114806?v=4" alt="@sathishkumar-manogaran" />](https://github.com/sathishkumar-manogaran) |
-| తెలుగు | [Telugu](../main/docs/translations/README.te.md) | []() |
-| ไทย | [Thai](../main/docs/translations/README.th.md) | [<img width="100" src="https://avatars0.githubusercontent.com/u/5433758?s=460&v=4" alt="@AimeTPGM" />](https://github.com/AimeTPGM) |
-| Tagalog | [Tagalog](../main/docs/translations/README.tl.md) | []() |
-| Türkçe | [Turkish](../main/docs/translations/README.tr.md) | [<img width="100" src="https://avatars3.githubusercontent.com/u/32689837?s=460&v=4" alt="@yamac-kurtulus" />](https://github.com/yamac-kurtulus) |
-| Українська | [Ukrainian](../main/docs/translations/README.ua.md) |  [<img width="100" src="https://avatars.githubusercontent.com/u/20286171?v=4" alt="@yamac-kurtulus" />](https://github.com/666f78)  |
-| Universal Alien | [Universal Alien](../main/docs/translations/README.un-aln.md) | [<img width="100" src="https://avatars.githubusercontent.com/u/68442560?v=4" alt="@debjit-bw" />]() |
-| اردو | [Urdu](../main/docs/translations/README.ur.md) | [<img width="100" src="https://avatars3.githubusercontent.com/u/4142795?s=460&v=4" alt="@Shhzdmrz" />](https://github.com/Shhzdmrz) |
-| Tiếng Việt | [Vietnamese](../main/docs/translations/README.vn.md) | [<img width="100" src="https://avatars3.githubusercontent.com/u/12371875?s=460&v=4" alt="@tranlyvu" />](https://github.com/tranlyvu) |
-| Yorùbá | [Yorùbá](../main/docs/translations/README.yor.md) | []() |
-| 中文 | [Chinese (Simplified)](../main/docs/translations/README.zh-cn.md) | [<img width="100" src="https://avatars2.githubusercontent.com/u/6414741?s=400&v=4" alt="@yuzhoujr" />](https://github.com/yuzhoujr) |
-| 中文 | [Chinese (Traditional)](../main/docs/translations/README.zh-tw.md) | [<img width="100" src="https://avatars2.githubusercontent.com/u/27748281?s=460&v=4" alt="@WeiChienHsu" />](https://github.com/WeiChienHsu) [<img width="100" src="https://avatars.githubusercontent.com/u/166942861?v=4" alt="@Sharl0tteIsTaken" />](https://github.com/Sharl0tteIsTaken) |
-| Zulu | [Zulu](../main/docs/translations/README.zul.md) | [<img width="100" src="https://avatars.githubusercontent.com/u/36197725?v=4" alt="@zecollokaris" />](https://github.com/zecollokaris) []() |
+| Afrikaans | [Afrikaans](../docs/translations/README.afk.md) | [<img width="100" src="https://avatars.githubusercontent.com/u/36197725?v=4" alt="@zecollokaris" />](https://github.com/zecollokaris) |
+| Albanian | [Albanian](../docs/translations/README.al.md) | [<img width="100" src="https://avatars.githubusercontent.com/u/40631828?v=4" alt="RronKurtishi" />](https://github.com/RronKurtishi) [<img width="100" src="https://avatars.githubusercontent.com/u/98396887?s=400&v=4" alt="RronKurtishi" />](https://github.com/auronvila) |
+| العربية | [Arabic](../docs/translations/README.ar.md) | [<img width="100" src="https://avatars.githubusercontent.com/u/83532081?v=4" alt="OsaidAlhomedy" />](https://github.com/OsaidAlhomedy) [<img width="100" src="https://avatars.githubusercontent.com/u/97640062?v=4" alt="AlaaYlula" />](https://github.com/AlaaYlula) [<img width="100" src="https://avatars.githubusercontent.com/u/60319236?v=4" alt="Laith-Alayassa" />](https://github.com/Laith-Alayassa) |
+| Azerbaijani | [Azerbaijani](../docs/translations/README.aze.md) | [<img width="100" src="https://avatars.githubusercontent.com/u/60487349?v=4" alt="@isakurbanov744" />](https://github.com/isakurbanov744)   [<img width="100" src="https://avatars.githubusercontent.com/u/58222828?v=4" alt="@Ahm3tJ4f" />](https://github.com/Ahm3tJ4f) |
+| Bulgarian | [Bulgarian](../docs/translations/README.bg.md) | []() |
+| Bosnian | [Bosnian](../docs/translations/README.bih.md) | []() |
+| বাংলা | [Bengali](../docs/translations/README.bn.md) | [<img width="100" src="https://avatars3.githubusercontent.com/u/12910423?s=460&v=4" alt="@cse031sust02" />](https://github.com/cse031sust02) |
+| Belarusian | [Belarusian](../docs/translations/README.by.md) | []() |
+| Català | [Catalan](../docs/translations/README.ca.md) | [<img width="100" src="https://avatars0.githubusercontent.com/u/16263046?s=460&v=4" alt="@Sergih28" />](https://github.com/Sergih28) |
+| čeština | [Czech](../docs/translations/README.cs.md) | []() |
+| Danish | [Danish](../docs/translations/README.da.md) | [<img width="100" src="https://avatars1.githubusercontent.com/u/15271858?s=460&v=4" alt="@7013145" />](https://github.com/7013145) |
+| Deutsch | [German](../docs/translations/README.de.md) | [<img width="100" src="https://avatars3.githubusercontent.com/u/22977266?s=460&v=4" alt="@lkreimann" />](https://github.com/lkreimann) |
+| المصرية | [Egyptian](../docs/translations/README.eg.md) | [<img width="100" src="https://avatars0.githubusercontent.com/u/12827629?s=460&v=4" alt="@MichaelKMalak" />](https://github.com/MichaelKMalak) |
+| English (Pirate) | [English (Pirate)](../docs/translations/README.en-pirate.md) | [<img width="100" src="https://avatars0.githubusercontent.com/u/956290?s=460&v=4" alt="@lukeoliff" />](https://github.com/lukeoliff) |
+| Español | [Spanish](../docs/translations/README.es.md) | [<img width="100" src="https://avatars3.githubusercontent.com/u/16923944?s=460&v=4" alt="@yirini" />](https://github.com/yirini) [<img width="100" src="https://avatars.githubusercontent.com/u/10425834?v=4" alt="@aaossa" />](https://github.com/aaossa) |
+| فارسی | [Persian](../docs/translations/README.fa.md) | [<img width="100" src="https://avatars2.githubusercontent.com/u/20030805?s=460&v=4" alt="@ThirdScript" />](https://github.com/ThirdScript) |
+| Finnish | [Finnish](../docs/translations/README.fi.md) | []() |
+| Français | [French](../docs/translations/README.fr.md) | [<img width="100" src="https://avatars0.githubusercontent.com/u/13402464?s=460&v=4" alt="@LePetitRenard" />](https://github.com/LePetitRenard) |
+| ქართული | [Georgian](../docs/translations/README.ka.md) | [<img width="100" src="https://avatars0.githubusercontent.com/u/9116447?s=460&v=4" alt="@iko1133" />](https://github.com/iko1133) |
+| Galego | [Galician](../docs/translations/README.gl.md) | [<img width="100" src="https://avatars1.githubusercontent.com/u/16878891?s=460&v=4" alt="@siderio2" />](https://github.com/siderio2) |
+| Greek | [Greek](../docs/translations/README.gr.md) |  [<img width="100" src="https://avatars.githubusercontent.com/u/63111742?v=4" alt="@adreaskar" />](https://github.com/adreaskar)   [<img width="100" src="https://avatars.githubusercontent.com/u/19299306?v=4" alt="@porfanid" />](https://github.com/porfanid)  |
+| ગુજરાતી | [Gujarati](../docs/translations/README.guj.md) | [<img width="100" src="https://avatars2.githubusercontent.com/u/38134283?s=460&v=4" alt="@smitgajjar" />](https://github.com/smitgajjar) [<img width="100" src="https://avatars.githubusercontent.com/u/16669911?v=4" alt="@kaushalgosaliya5" />](https://github.com/kaushalgosaliya5/) |
+| Hausa | [Hausa](../docs/translations/README.hau.md) | []() |
+| עברית | [Hebrew](../docs/translations/README.hb.md) | [<img width="100" src="https://avatars1.githubusercontent.com/u/23402988?s=460&v=4" alt="@TomerPacific" />](https://github.com/TomerPacific) |
+| हिन्दी | [Hindi](../docs/translations/README.hi.md) | [<img width="100" src="https://avatars2.githubusercontent.com/u/4654382?s=460&v=4" alt="@arshadkazmi42" />](https://github.com/arshadkazmi42) [<img width="100" src="https://avatars2.githubusercontent.com/u/7047079?s=460&v=4" alt="@sara-02" />](https://github.com/sara-02) [<img width="100" src="https://avatars.githubusercontent.com/u/20799404?v=4" alt="shrut1996" />](https://github.com/shrut1996) |
+| Chhattisgarhi | [Chhattisgarhi](../docs/translations/README.hne.md) | [<img width="100" src="https://avatars2.githubusercontent.com/u/54806739?s=400&v=4" alt="@pradyyadav" />](https://github.com/pradyyadav) |
+| Magyar | [Hungarian](../docs/translations/README.hu.md) | []() |
+| Armenian | [Armenian](../docs/translations/README.hy.md) | []() |
+| Indonesian | [Indonesian](../docs/translations/README.id.md) | [<img width="100" src="https://avatars0.githubusercontent.com/u/315048?s=460&v=4" alt="@hahn" />](https://github.com/hahn) |
+| Igbo | [Igbo](../docs/translations/README.igb.md) | [<img width="100" src="https://avatars.githubusercontent.com/u/36197725?v=4" alt="@zecollokaris" />](https://github.com/zecollokaris) []() |
+| Italiano | [Italian](../docs/translations/README.it.md) | [<img width="100" src="https://avatars0.githubusercontent.com/u/22260641?s=460&v=4" alt="@platipo" />](https://github.com/platipo) |
+| 日本語 | [Japanese](../docs/translations/README.ja.md) | [<img width="100" src="https://avatars3.githubusercontent.com/u/12928246?s=460&v=4" alt="@cbondurant" />](https://github.com/cbondurant) |
+| ಕನ್ನಡ | [Kannada](../docs/translations/README.ka.md) | []() |
+| 한국어 | [Korean](../docs/translations/README.ko.md) | [<img width="100" src="https://avatars0.githubusercontent.com/u/2732120?s=460&v=4" alt="@espozbob" />](https://github.com/espozbob) |
+| Kiswahili | [Kiswahili](../docs/translations/README.kws.md) |[<img width="100" src="https://avatars.githubusercontent.com/u/36197725?v=4" alt="@zecollokaris" />](https://github.com/zecollokaris)  []() |
+| Kazakh | [Kazakh](../docs/translations/README.kz.md) | [<img width="100" src="https://avatars3.githubusercontent.com/u/12928246?s=460&v=4" alt="@kurshakuz" />](https://github.com/kurshakuz) |
+| Lietuvių kalba | [Lithuanian](../docs/translations/README.lt.md) | [<img width="100" src="https://avatars1.githubusercontent.com/u/9092712?s=460&v=4" alt="@neone35" />](https://github.com/neone35) |
+| Latviešu valoda | [Latvian](../docs/translations/README.lv.md) | []() |
+|  | [me](../docs/translations/README.me.md) | [<img width="100" src="https://avatars1.githubusercontent.com/u/9092712?s=460&v=4" alt="@neone35">]() |
+| Македонски | [Macedonian](../docs/translations/README.mk.md) | []() |
+| മലയാളം | [Malayalam](../docs/translations/README.ml.md) | [<img width="100" src="https://avatars.githubusercontent.com/u/3657426?v=4" alt="@yedhukrishnan">](https://github.com/yedhukrishnan) |
+| Burmese | [Burmese](../docs/translations/README.mm_unicode.md) | [<img width="100" src="https://avatars0.githubusercontent.com/u/13135332?s=460&v=4" alt="@lwinkyawmyat" />](https://github.com/lwinkyawmyat) |
+| मराठी | [Marathi](../docs/translations/README.mr.md) | [<img width="100" src="https://avatars1.githubusercontent.com/u/16685565?s=460&v=4" alt="@bantya" />](https://github.com/bantya) |
+| Español de México | [Spanish of Mexico](../docs/translations/README.mx.md) | []() |
+| Bahasa Melayu | [Malay](../docs/translations/README.my.md) | []() |
+| Nederlandse | [Dutch](../docs/translations/README.nl.md) | [<img width="100" src="https://avatars0.githubusercontent.com/u/3897815?s=460&v=4" alt="@MJMajoor" />](https://github.com/MJMajoor) |
+| Norsk | [Norwegian](../docs/translations/README.no.md) | [<img width="100" src="https://avatars.githubusercontent.com/u/75746434?s=400&u=0a0854f15eb1f7fd5169d108bb1f12f875c172c6&v=4" alt="Islandstone89 on Github" />](https://github.com/Islandstone89) |
+| नेपाली | [Nepali](../docs/translations/README.np.md) | [<img width="100" src="https://avatars2.githubusercontent.com/u/2145263?s=460&v=4" alt="@milap-neupane" />](https://github.com/milap-neupane) |
+| ਪੰਜਾਬੀ | [Punjabi](../docs/translations/README.pb.md) | []() |
+| Polski | [Polish](../docs/translations/README.pl.md) | [<img width="100" src="https://avatars0.githubusercontent.com/u/3372341?s=460&v=4" alt="@P1X3L0V4" />](https://github.com/P1X3L0V4) [<img width="100" src="https://avatars2.githubusercontent.com/u/1311358?v=4" alt="@mikowhy" />](https://github.com/mikowhy) |
+| Português | [Portugues (Portugal)](../docs/translations/README.pt-pt.md) | [<img width="100" src="https://avatars.githubusercontent.com/u/36346554?v=4" alt="@RamosCSV" />](https://github.com/RamosCSV) |
+| Português do Brasil | [Portugues (Brazil)](../docs/translations/README.pt_br.md) | [<img width="100" src="https://avatars2.githubusercontent.com/u/10578275?s=460&v=4" alt="@OtacilioN" />](https://github.com/OtacilioN) [<img width="100" src="https://avatars2.githubusercontent.com/u/47339825?s=460&v=4" alt="@gabrielsanttana" />](https://github.com/gabrielsanttana)|
+| Română | [Romanian](../docs/translations/README.ro.md) | [ <img width="100" src="https://avatars2.githubusercontent.com/u/20670448?s=460&v=4" alt="@dp97" />](https://github.com/dp97) |
+| Русский | [Russian](../docs/translations/README.ru.md) | [<img width="100" src="https://avatars2.githubusercontent.com/u/4745723?s=460&v=4" alt="@ayanovsk" />](https://github.com/ayanovsk) |
+| Svenska | [Swedish](../docs/translations/README.se.md) | [<img width="100" src="https://avatars0.githubusercontent.com/u/2447741?s=460&v=4" alt="@jcer" />](https://github.com/jcer) |
+| Sinhala | [Sinhala](../docs/translations/README.si.md) | []() |
+| Sindhi | [Sindhi](../docs/translations/README.sindhi.md) | []() |
+| Slovenčina | [Slovak](../docs/translations/README.sk.md) | [<img width="100" src="https://avatars3.githubusercontent.com/u/16558136?s=460&v=4" alt="@CoderKlemen" />](https://github.com/CoderKlemen) |
+| Slovenščina | [Slovenian](../docs/translations/README.slk.md) | [<img width="100" src="https://avatars0.githubusercontent.com/u/11976353?s=460&v=4" alt="@hercegtomas" />](https://github.com/hercegtomas) |
+| Српски | [Serbian (Cyrillic)](../docs/translations/README.sr-Cyrl.md) | [<img width="100" src="https://avatars.githubusercontent.com/u/40705899?v=4" alt="@rammba" />](https://github.com/rammba) |
+| Srpski | [Serbian (Latin)](../docs/translations/README.sr-Latn.md) | [<img width="100" src="https://avatars.githubusercontent.com/u/35745051?v=4" alt="@Mateja3m" />](https://github.com/Mateja3m) [<img width="100" src="https://avatars.githubusercontent.com/u/40705899?v=4" alt="@rammba" />](https://github.com/rammba) |
+| தமிழ் | [Tamil](../docs/translations/README.ta.md) | [<img width="100" src="https://avatars.githubusercontent.com/u/7114806?v=4" alt="@sathishkumar-manogaran" />](https://github.com/sathishkumar-manogaran) |
+| తెలుగు | [Telugu](../docs/translations/README.te.md) | []() |
+| ไทย | [Thai](../docs/translations/README.th.md) | [<img width="100" src="https://avatars0.githubusercontent.com/u/5433758?s=460&v=4" alt="@AimeTPGM" />](https://github.com/AimeTPGM) |
+| Tagalog | [Tagalog](../docs/translations/README.tl.md) | []() |
+| Türkçe | [Turkish](../docs/translations/README.tr.md) | [<img width="100" src="https://avatars3.githubusercontent.com/u/32689837?s=460&v=4" alt="@yamac-kurtulus" />](https://github.com/yamac-kurtulus) |
+| Українська | [Ukrainian](../docs/translations/README.ua.md) |  [<img width="100" src="https://avatars.githubusercontent.com/u/20286171?v=4" alt="@yamac-kurtulus" />](https://github.com/666f78)  |
+| Universal Alien | [Universal Alien](../docs/translations/README.un-aln.md) | [<img width="100" src="https://avatars.githubusercontent.com/u/68442560?v=4" alt="@debjit-bw" />]() |
+| اردو | [Urdu](../docs/translations/README.ur.md) | [<img width="100" src="https://avatars3.githubusercontent.com/u/4142795?s=460&v=4" alt="@Shhzdmrz" />](https://github.com/Shhzdmrz) |
+| Tiếng Việt | [Vietnamese](../docs/translations/README.vn.md) | [<img width="100" src="https://avatars3.githubusercontent.com/u/12371875?s=460&v=4" alt="@tranlyvu" />](https://github.com/tranlyvu) |
+| Yorùbá | [Yorùbá](../docs/translations/README.yor.md) | []() |
+| 中文 | [Chinese (Simplified)](../docs/translations/README.zh-cn.md) | [<img width="100" src="https://avatars2.githubusercontent.com/u/6414741?s=400&v=4" alt="@yuzhoujr" />](https://github.com/yuzhoujr) |
+| 中文 | [Chinese (Traditional)](../docs/translations/README.zh-tw.md) | [<img width="100" src="https://avatars2.githubusercontent.com/u/27748281?s=460&v=4" alt="@WeiChienHsu" />](https://github.com/WeiChienHsu) [<img width="100" src="https://avatars.githubusercontent.com/u/166942861?v=4" alt="@Sharl0tteIsTaken" />](https://github.com/Sharl0tteIsTaken) |
+| Zulu | [Zulu](../docs/translations/README.zul.md) | [<img width="100" src="https://avatars.githubusercontent.com/u/36197725?v=4" alt="@zecollokaris" />](https://github.com/zecollokaris) []() |
 


### PR DESCRIPTION
This PR fixes the broken links in the "Name in English" column by removing /main from the file paths.
Addresses #106386