### PR TITLE
Added bash syntax specs to Ghanaian README code blocks #105987

### DIFF
--- a/docs/translations/README.gh.md
+++ b/docs/translations/README.gh.md
@@ -25,7 +25,7 @@ Afei clone saa akoraeɛ yi kɔ wo kɔmputa so. Klik clone button no so na afei k
 
 Bue ahyɛdeɛ kwan (sɛ wowɔ Windows so) anaa terminal (sɛ wowɔ MacOS anaa Linux so) na yɛ git ahyɛdeɛ a ɛdidi soɔ yi:
 
-```
+```bash
 git clone "URL a woayɛ ho kɔpi nkyɛe no"
 ```
 baabi a "URL a woayɛ ho kɔpi seesei ara" (a nsɛm a wɔafa aka no nka ho) yɛ akoraeɛ URL.
@@ -33,7 +33,7 @@ baabi a "URL a woayɛ ho kɔpi seesei ara" (a nsɛm a wɔafa aka no nka ho) yɛ 
 <img align="right" width="300" src="https://firstcontributions.github.io/assets/Readme/copy-to-clipboard.png" alt="copy URL to clipboard" />
 
 Nhwɛsoɔ:
-```
+```bash
 git clone https://github.com/your-username/first-contributions.git
 ```
 baabi a `wo-ɔdefoɔ din` yɛ wo GitHub dwumadie din. Ɛha na worekɔpi `ntoboa ahorow a edi kan` akoraeɛ no mu nsɛm afiri GitHub so akɔ wo kɔmputa so.
@@ -42,16 +42,16 @@ baabi a `wo-ɔdefoɔ din` yɛ wo GitHub dwumadie din. Ɛha na worekɔpi `ntoboa 
 
 Kɔ adwuma no ho kyerɛwtohɔ a wɔayɛ no foforo no so (sɛ woankɔ hɔ dedaw a):
 
-```
+```bash
 cd first-contributions
 ```
 Afei fa `git checkout` ahyɛdeɛ no yɛ baa dwumadibea:
-```
+```bash
 git checkout -b <fa-wo-din ka ho>
 ```
 
 Nhwɛsoɔ:
-```
+```bash
 git checkout -b add-quarjo-wusu
 ```
 (Ɛnsɛ sɛ baa dwumadibea din no kura asɛmfua *add*, nanso ntease wom sɛ wode bɛka ho efisɛ baa dwumadibea yi atirimpɔw ne sɛ wode wo din bɛka list bi ho.)
@@ -59,12 +59,12 @@ git checkout -b add-quarjo-wusu
 ## Yɛ Nsakrae a Ɛho Hia na Fa Hyɛ
 
 Afei, bue `Contributors.md` fael no wɔ text editor mu, fa wo din ka ho, na sie fael no. Sɛ wobue ahyɛdeɛ no na wo tu `git status` ahyɛdeɛ no a, wobɛhunu sɛ nsakraeɛ bi wɔ hɔ. Fa nsakrae yi ka baa dwumadibea a woayɛ nkyɛe no ho denam `git add` ahyɛde no so:
-```
+```bash
 git add Contributors.md
 ```
 
 Afei fa `git commit` ahyɛdeɛ no yɛ nsakraeɛ yi:
-```
+```bash
 git commit -m "Add <wo-din> kɔ Contributors list no so"
 ```
 fa wo din si `<wo-din>` ananmu.
@@ -72,7 +72,7 @@ fa wo din si `<wo-din>` ananmu.
 ## Pia Nsakraeɛ kɔ GitHub
 
 Fa `git push` ahyɛdeɛ no pia wo nsakraeɛ no:
-```
+```bash
 git push origin <fa-wo-din ka ho>
 ```
 fa baa dwumadibea a woadi kan abɔ no din si `<fa-wo-din ka ho>` ananmu.
@@ -94,36 +94,36 @@ Wɔrensakra wo fork no nkorabata titiriw no wɔ saa bere yi mu. Sɛnea ɛbɛyɛ 
 ## Ma Wo Fork no ne Saa Adekorabea Yi Nhyia
 
 Nea edi kan no, dan kɔ baa dwumadibea titiriw no so:
-```
+```bash
 git checkout main
 ```
 
 Na fa me akoraeɛ URL no ka ho sɛ `upstream akyirikyiri url`:
-```
+```bash
 git remote add upstream https://github.com/Roshanjossey/first-contributions
 ```
 Wei yɛ ɔkwan a yɛbɛfa so aka akyerɛ Git sɛ saa akoraeɛ yi nkyerɛaseɛ foforɔ wɔ hɔ wɔ address a wɔakyerɛ no so, na yɛfrɛ no `upstream`. Sɛ wɔka nsakraeɛ no bom wie a, hwehwɛ me akoraeɛ no foforɔ no:
-```
+```bash
 git fetch upstream
 ```
 
 Ɛha na yɛrefa nsakraeɛ a ɛwɔ me baa dwumadibea a ɛwɔ soro no nyinaa aba.Afei ɛsɛ sɛ wode me akorae no mu nsakrae foforo no bom ne wo baa dwumadibea titiriw no:
-```
+```bash
 git rebase upstream/main
 ```
 Ɛha na yɛde nsakraeɛ a wode baa wo baa dwumadibea kɛseɛ no nyinaa redi dwuma.Sɛ wopia baa dwumadibea kɛse no mprempren a, wo kyɛnsee no nso benya nsakrae ahorow no:
 
-```
+```bash
 git push origin main
 ```
 Kɔkɔbɔ: Saa bere yi de, worepia akɔ akyirikyiri adekorabea a wɔfrɛ no origin no so.
 
 Saa bere yi, mede wo `<fa-wo-din ka ho>` baa dwumadibea no kaa me baa dwumadibea kɛse no ho, na wo nso wode me baa dwumadibea kɛse no kaa wo baa dwumadibea titiriw no ho. Wo `<fa-wo-din ka ho>` baa dwumadibea no ho nhia bio, enti wubetumi apopa:
-```
+```bash
 git branch -d <add-your-name>
 ```
 na wubetumi nso apopa ne akyirikyiri nkyerɛase no:
-```
+```bash
 git push origin --delete <add-your-name>
 ```
 Eyi ho nhia, nanso baa dwumadibea no din kyerɛ sɛ n’atirimpɔw yɛ pɔtee koraa. Ne nkwa nna betumi ayɛ tiaa.


### PR DESCRIPTION
- Problem
The Ghanaian translation has code blocks without language specifications (just `instead of` bash), which prevents proper syntax highlighting and makes the commands less readable.

- Solution
Added bash language tag to all shell command code blocks in docs/translations/README.gh.md.
Improved readability and syntax highlighting in the Ghanaian translation README.

Resolves #105987 