### PR TITLE
Added bash syntax specs to Gujarati README code blocks #105939

### DIFF
--- a/docs/translations/README.guj.md
+++ b/docs/translations/README.guj.md
@@ -26,7 +26,7 @@
 
 તમારા કમ્પ્યુટર પર એક ટર્મિનલ / કમાંડ પ્રોમ્પ્ટ ખોલો અને નીચે દર્શાવ્યા મુજબ git આદેશ ચલાવો:
 
-```
+```bash
 git clone "યુઆરએલ જે તમે હમણાં જ નકલ(ક્લોન) કરી"
 ```
 
@@ -34,7 +34,7 @@ git clone "યુઆરએલ જે તમે હમણાં જ નકલ(ક
 
 ઉદાહરણ તરીકે:
 
-```
+```bash
 git clone https://github.com/આ-તમે-છો/first-contributions.git
 ```
 
@@ -46,19 +46,19 @@ git clone https://github.com/આ-તમે-છો/first-contributions.git
 
 તમારા કમ્પ્યુટર પર બનાવેલ રિપોઝીટરીની કોપીનાં ફોલ્ડર / ડિરેક્ટરીમાં જાવ (જો હજુ સુધી તમે ત્યાં ન હોવ તો નીચે આપેલ Command(આદેશ) ચલાવો)
 
-```
+```bash
 cd first-contributions
 ```
 
 હવે 'git checkout' command(આદેશ) નો ઉપયોગ કરીને એક નવી શાખા(Branch) બનાવો. નવી શાખા(Branch) બનાવવા માટે -b વિકલ્પનો ઉપયોગ થાય છે.
 
-```
+```bash
 git checkout -b <તમારી-શાખા-નામ-ઉમેરો>
 ```
 
 ઉદાહરણ તરીકે:
 
-```
+```bash
 git checkout -b add-alonzo-church
 ```
 
@@ -72,13 +72,13 @@ git checkout -b add-alonzo-church
 
 જો તમે પ્રોજેક્ટની ડાઈરેક્ટરીમા જશો અને કમાન્ડ પ્રોમ્પ્ટમાં `git status` નિર્દેશ ચલાવશો, તો તમે કરેલા પરિવર્તન જોઈ શક્શો. તે પરિવર્તન બનાવવામાં આવેલ શાખા(Branch)માં ઉમેરવા માટે 'git add` કમાન્ડ વાપરો.
 
-```
+```bash
 git add Contributors.md
 ```
 
 હવે તમારા પોતાના ફેરફારોને 'git commit' આદેશનો ઉપયોગ કરી કમીટ કરો.
 
-```
+```bash
 git commit -m "Add <તમારુ-નામ> to Contributors list"
 ```
 
@@ -90,7 +90,7 @@ git commit -m "Add <તમારુ-નામ> to Contributors list"
 
 `git push` ઉપયોગ કરીને તમારા પરિવર્તન ને પુશ કરો
 
-```
+```bash
 git push origin <તમારી-શાખા-નામ-ઉમેરો>
 ```
 


### PR DESCRIPTION
- Problem
The Gujarati translation has code blocks without language specifications (just `instead of` bash), which prevents proper syntax highlighting and makes the commands less readable.

- Solution
Added bash language tag to all shell command code blocks in docs/translations/README.guj.md.
Improved readability and syntax highlighting in the Gujarati translation README.

Resolves #105939 