### PR TITLE
Added bash syntax specs to Finnish README code blocks #105870

### DIFF
--- a/docs/translations/README.fi.md
+++ b/docs/translations/README.fi.md
@@ -28,7 +28,7 @@ Seuraavaksi kloonaa juuri forkkaamasi repositorio koneellesi. Mene GitHub käytt
 
 Avaa komentorivi ja syötä seuraava git-komento:
 
-```
+```bash
 git clone "Juuri kopioimasi URL"
 ```
 
@@ -38,7 +38,7 @@ git clone "Juuri kopioimasi URL"
 
 Esimerkiksi:
 
-```
+```bash
 git clone https://github.com/nimesi/first-contributions.git
 ```
 
@@ -48,19 +48,19 @@ Kirjoita GitHub-käyttäjänimesi 'nimesi' teksin sijaan. Tämä komento kopioi 
 
 Mene repositoriosi kansioon koneellasi (ellet jo ole siellä).
 
-```
+```bash
 cd first-contributions
 ```
 
 Seuraavaksi luo branch komennolla `git checkout`:
 
-```
+```bash
 git checkout -b <lisaa-sinun-branchin-nimi>
 ```
 
 Esimerkiksi:
 
-```
+```bash
 git checkout -b add-matti-meikalainen
 ```
 
@@ -76,13 +76,13 @@ Jos menet projektin kansioon ja syötät komennon `git status`, näet muutokset.
 
 Lisää nuo muutokset branchiin `git add` komennolla:
 
-```
+```bash
 git add Contributors.md
 ```
 
 Seuraavaksi committoi muutokset `git commit` komennolla:
 
-```
+```bash
 git commit -m "Add <sinun-nimesi> to Contributors list"
 ```
 
@@ -92,7 +92,7 @@ Korvaamalla `<sinun-nimesi>` nimelläsi.
 
 Pushaa muutoksesi komennolla `git push`:
 
-```
+```bash
 git push origin <lisaa-branchisi-nimi>
 ```
 


### PR DESCRIPTION
- Problem
The Finnish translation has code blocks without language specifications (just `instead of` bash), which prevents proper syntax highlighting and makes the commands less readable.

- Solution
Added bash language tag to all shell command code blocks in docs/translations/README.fi.md.
Improved readability and syntax highlighting in the Finnish README.

Resolves #105870 