### PR TITLE
Add bash language specification to code blocks in Portuguese (Brazil)… translation

### DIFF
--- a/docs/translations/README.pt_br.md
+++ b/docs/translations/README.pt_br.md
@@ -34,7 +34,7 @@ onde "url que copiou" (sem as aspas) é a URL deste repositório (seu fork deste
 
 Por exemplo:
 
-```
+```bash
 git clone https://github.com/seu-usuario/first-contributions.git
 ```
 
@@ -76,7 +76,7 @@ git add Contributors.md
 
 Agora, confirme essas alterações usando o comando git commit `git commit`:
 
-```
+```bash
 git commit -m "Add <seu-nome> to Contributors list"
 ```
 
@@ -86,7 +86,7 @@ substituindo `<seu-nome>` pelo seu nome.
 
 Envie suas alterações usando o comando `git push`:
 
-```
+```bash
 git push origin <nome-da-sua-branch>
 ```
 

--- a/docs/translations/README.pt_br.md
+++ b/docs/translations/README.pt_br.md
@@ -24,7 +24,7 @@ Agora clone este repositório para a sua máquina. Clique no botão "_Code_" e, 
 
 Abra um terminal e execute o seguinte comando do git:
 
-```
+```bash
 git clone "url que copiou"
 ```
 
@@ -44,19 +44,19 @@ onde "seu-usuário" é o seu usuário do _GitHub_. Aqui você estará copiando o
 
 Acesse o diretório do repositório no seu computador (caso você não esteja nele):
 
-```
+```bash
 cd first-contributions
 ```
 
 Agora crie um _Branch_ usando o comando `git switch`:
 
-```
+```bash
 git switch -c <nome-da-sua-nova-branch>
 ```
 
 Por exemplo:
 
-```
+```bash
 git switch -c add-andre-oliveira
 ```
 
@@ -70,7 +70,7 @@ Agora, abra o arquivo `Contributors.md` em seu editor de código e adicione o se
 
 Se você for para o diretório do projeto e executar o comando `git status`, verá que há alterações. Adicione essas alterações ao _Branch_ que você acabou de criar utilizando o comando `git add`:
 
-```
+```bash
 git add Contributors.md
 ```
 


### PR DESCRIPTION
hi maintainers iam solved #105933 by adding bash language specification to all shell command code blocks in the language translation of README.
I updated 'docs/translations/README.pt_br.md'
It resolves #105933 
I hope this update made by me improves code readability and consistency.