### PR TITLE
README Update: Added Hindi translation and Indian flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 #### _Read this in [other languages](docs/translations/Translations.md)._
 <kbd>[<img title="Shqip" alt="Shqip" src="https://cdn.statically.io/gh/hjnilsson/country-flags/master/svg/al.svg" width="22">](docs/translations/README.al.md)</kbd>
+<kbd>[<img title="हिन्दी" alt="Hindi" src="https://cdn.statically.io/gh/hjnilsson/country-flags/master/svg/in.svg" width="22">](docs/translations/README.hi.md)</kbd>
 <kbd>[<img title="Armenian" alt="Armenian" src="https://cdn.statically.io/gh/hjnilsson/country-flags/master/svg/am.svg" width="22">](docs/translations/README.arm.md)</kbd>
 <kbd>[<img title="Uzbek" alt="Uzbek language" src="https://cdn.statically.io/gh/hjnilsson/country-flags/master/svg/uz.svg" width="22">](docs/translations/README.uz.md)</kbd>
 <kbd>[<img title="Azərbaycan dili" alt="Azərbaycan dili" src="https://cdn.statically.io/flags/az.svg" width="22">](docs/translations/README.aze.md)</kbd>


### PR DESCRIPTION
This PR adds a Hindi (हिन्दी) translation link to the README.md file along with the Indian flag icon (🇮🇳).
The goal is to make the documentation more accessible for Hindi-speaking contributors and users.

🛠️ Changes Made

Added a Hindi translation link in the Translations section of the README.md.

Included the Indian flag icon (in.svg) for visual clarity and consistency.

Ensured the formatting matches the existing <kbd> style used for other languages.

Maintained the same flag size (width="22") and alignment for uniformity.

✅ How to Verify

Open the updated README.md file.

Scroll to the “Read this in other languages” section.

Confirm that:

The Hindi (हिन्दी) option is visible.

The Indian flag 🇮🇳 appears correctly.

The link points to the correct file path → docs/translations/README.hi.md.