### PR TITLE
Translate README.od.md content to Odia

### DIFF
--- a/docs/translations/README.od.md
+++ b/docs/translations/README.od.md
@@ -66,9 +66,9 @@ git switch -c add-alonzo-church
 
 ବର୍ତ୍ତମାନ ଟେକ୍ସଟ୍ ଏଡିଟର୍ ରେ `Contributors.md` ଫାଇଲ୍ ଖୋଲ, ଏଥିରେ ତୁମର ନାମ ଯୋଡ | ଫାଇଲ୍ ର ଆରମ୍ଭ କିମ୍ବା ଶେଷରେ ଏହାକୁ ଯୋଡନ୍ତୁ ନାହିଁ | ଏହାକୁ ଯେକ ଣସି ସ୍ଥାନରେ ରଖନ୍ତୁ | ବର୍ତ୍ତମାନ, ଫାଇଲ୍ ସେଭ୍ କରନ୍ତୁ |
 
-<img align = "right" width = "450" src = "https://firstcontributions.github.io/assets/Readme/git-status.png" alt = "git status" />
+<img align = "right" width = "450" src = "https://firstcontributions.github.io/assets/Readme/git-status.png" alt = "ଗିଟ ସ୍ଥିତି" />
 
-ଯଦି ଆପଣ ପ୍ରୋଜେକ୍ଟ ଡିରେକ୍ଟୋରୀକୁ ଯାଆନ୍ତି ଏବଂ `git status` କମାଣ୍ଡ୍ ଏକଜେକ୍ୟୁଟ୍ କରନ୍ତି, ଆପଣ ଦେଖିବେ ସେଠାରେ କିଛି ପରିବର୍ତ୍ତନ ଅଛି |
+ଯଦି ଆପଣ ପ୍ରୋଜେକ୍ଟ ଡିରେକ୍ଟୋରୀକୁ ଯାଆନ୍ତି ଏବଂ `ଗିଟ ସ୍ଥିତି` କମାଣ୍ଡ୍ ଏକଜେକ୍ୟୁଟ୍ କରନ୍ତି, ଆପଣ ଦେଖିବେ ସେଠାରେ କିଛି ପରିବର୍ତ୍ତନ ଅଛି |
 
 ସେହି ପରିବର୍ତ୍ତନଗୁଡ଼ିକୁ ଆପଣ `git add` କମାଣ୍ଡ ବ୍ୟବହାର କରି ସୃଷ୍ଟି କରିଥିବା ଶାଖାରେ ଯୋଡନ୍ତୁ:
 


### PR DESCRIPTION
This pull request improves accessibility for Odia readers by translating the English alt text of all tutorial images in the Odia README file (docs/translations/README.od.md). Previously, the Odia translation contained English alt text such as "git status" , which made it difficult for Odia speakers using screen readers or text-to-speech tools to understand the image context.

Before submitting this pull request, check the changes to see it's only the changes you made intentionally
If there are changes to other lines you didn't make deliberately, it's possible that your IDE made the changes with a utility like prettier.
Next time, make sure that you only add your changes by using `git add -p` and rather than `git add Contributors.md`

If you're doing something in the checklist below, put an `x` inside `[ ]` so that `- [ ]` becomes `- [x]`

- [x] I had fun going through this tutorial (ノ^o^)ノ and learned on the way ٩(＾◡＾)۶
- [x] There are some things I'd like to improve in this tutorial. I have written them below.
- [x] There were steps where I had errors while following this tutorial. I have written them below.