### PR TITLE
Removed all slack links from Zulu README #104809

### DIFF
--- a/docs/translations/README.zul.md
+++ b/docs/translations/README.zul.md
@@ -115,7 +115,6 @@ Siyakuhalalisela! Usanda kuqedela umshini ojwayelekile -> clone -> edit -> PR uk
 
 Gubha umnikelo wakho bese uwabelana nabangani bakho nabalandeli ngokuya kuhlelo [lokusebenza lewebhu](https://firstcontributions.github.io/#social-share).
 
-Ungakwazi ukujoyina ithimba lethu elihle uma kwenzeka udinga noma yiluphi usizo noma unemibuzo. [Joyina ithimba le-slack](https://join.slack.com/t/firstcontributors/shared_invite/zt-1hg51qkgm-Xc7HxhsiPYNN3ofX2_I8FA).
 
 Manje ake siqale ngokunikela ngeminye imiklamo. Senze uhlu lwamaphrojekthi ngezinkinga ezilula ongaqala ngazo. Hlola  [uhlu lwamaphrojekthi kuhlelo lokusebenza lewebhu .](https://firstcontributions.github.io/#project-list).
 


### PR DESCRIPTION
- Goal 
Have no links to slack

- Solution
Removed all the links to slack from /docs/translations/README.zul.md

Resolves #104809 