### PR TITLE
Remove slack link logo and link from github-cli-tutorial.md

### DIFF
--- a/docs/cli-tool-tutorials/github-cli-tutorial.md
+++ b/docs/cli-tool-tutorials/github-cli-tutorial.md
@@ -1,5 +1,4 @@
 [![Open Source Love](https://badges.frapsoft.com/os/v1/open-source.svg?v=103)](https://github.com/ellerbrock/open-source-badges/)
-[<img align="right" width="150" src="https://firstcontributions.github.io/assets/gui-tool-tutorials/github-desktop-tutorial/join-slack-team.png">](https://join.slack.com/t/firstcontributors/shared_invite/enQtNjkxNzQwNzA2MTMwLTVhMWJjNjg2ODRlNWZhNjIzYjgwNDIyZWYwZjhjYTQ4OTBjMWM0MmFhZDUxNzBiYzczMGNiYzcxNjkzZDZlMDM)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 [![Open Source Helpers](https://www.codetriage.com/roshanjossey/first-contributions/badges/users.svg)](https://www.codetriage.com/roshanjossey/first-contributions)
 
@@ -98,12 +97,10 @@ Congratulations! You have just completed the standard _fork -> clone -> edit -> 
 
 Celebrate your contribution and share it with your friends and followers by going to [web app](https://firstcontributions.github.io/#social-share).
 
-You could join our slack team if you need any help or have any questions. [Join slack team](https://join.slack.com/t/firstcontributors/shared_invite/zt-vchl8cde-S0KstI_jyCcGEEj7rSTQiA).
+If you'd like more practice, checkout [code contributions](https://github.com/roshanjossey/code-contributions).
 
 Now let's get you started with contributing to other projects. We've compiled a list of projects with easy issues you can get started on. Check out [the list of projects in the web app](https://firstcontributions.github.io/#project-list).
 
-### [Additional material](additional-material/git_workflow_scenarios/additional-material.md)
-
-## Tutorials Using Other Tools
+### [Additional material](https://github.com/firstcontributions/first-contributions/blob/main/docs/additional-material/git_workflow_scenarios/additional-material.md)
 
 [Back to main page](https://github.com/firstcontributions/first-contributions#tutorials-using-other-tools)


### PR DESCRIPTION
Removed outdated Slack team invitation link at the top and replace the join slack team link in the bottom to code contribution repository link. 
In addition updated the link for the additional material and removed 'Tutorials Using Other Tools' header as there is no tutorial specified. But if the other tools section is needed it can be like the main README.md.
Based on #106786 .
