### PR TITLE
Added bash syntax specs to Turkmen README code blocks #105979

### DIFF
--- a/docs/translations/README.tm.md
+++ b/docs/translations/README.tm.md
@@ -72,12 +72,12 @@ git switch -c goş-ahmet-ahmedow
 
 Indi, tekst redaktorynda(m.ü VSCode) `Contributors.md` faýlyny açyň, içinde iň soňunda adyňyzy giriziň we ýatda saklaň(save)
 
-```
+```bash
 - [Adyňyz](https://github.com/ulanyjy-adyňyz)
 ```
 
 Mysal üçin:
-```
+```bash
 - [Ahmet Ahmedow](https://github.com/ahmetahmedow)
 ```
 ```](``` arasynda boşluk ýokdur


### PR DESCRIPTION
- Goal
Add missing bash language specification to shell command code blocks in the Turkmen translation README for better syntax highlighting.

- Solution
Added bash language tag to all shell command code blocks in docs/translations/README.tm.md.
Improved readability and syntax highlighting in the Turkmen README.

Resolves #105979
