### PR TITLE
Clarify branch creation step in README for older Git versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,10 +135,22 @@ Change to the repository directory on your computer (if you are not already ther
 cd first-contributions
 ```
 
-Now create a branch using the `git switch` command:
+Now create a branch using the `git switch` command (Git 2.23 or newer):
 
 ```bash
 git switch -c your-new-branch-name
+```
+
+If you are using an older Git version that doesn’t support `git switch`, use:
+
+```bash
+git checkout -b your-new-branch-name
+```
+
+You can check your Git version with:
+
+```bash
+git --version
 ```
 
 For example:
@@ -147,18 +159,6 @@ For example:
 git switch -c add-alonzo-church
 ```
 
-<details>
-<summary> <strong>If you get any errors using git switch, click here:</strong> </summary>
-
-If the error message "Git: `switch` is not a git command. See `git –help`" appears, it's likely because you're using an older version of git.
-
-In this case, try to use `git checkout` instead:
-
-```bash
-git checkout -b your-new-branch-name
-```
-
-</details>
 
 ## Make necessary changes and commit those changes
 


### PR DESCRIPTION
Updated the "Create a branch" section in README to make instructions clearer for beginners.

- Mentioned that `git switch` requires Git 2.23 or newer
- Added fallback command `git checkout -b` for older Git versions
- Added `git --version` to help users check their Git version

This improves clarity and reduces confusion for first-time contributors using older Git installations.

Before submitting this pull request, check the changes to see it's only the changes you made intentionally
If there are changes to other lines you didn't make deliberately, it's possible that your IDE made the changes with a utility like prettier.
Next time, make sure that you only add your changes by using `git add -p` and rather than `git add Contributors.md`

If you're doing something in the checklist below, put an `x` inside `[ ]` so that `- [ ]` becomes `- [x]`

- [x] I had fun going through this tutorial (ノ^o^)ノ and learned on the way ٩(＾◡＾)۶
- [x] There are some things I'd like to improve in this tutorial. I have written them below.
- [x] There were steps where I had errors while following this tutorial. I have written them below.