### PR TITLE
transaled from eglish to turkish

### DIFF
--- a/docs/translations/README.ps.md
+++ b/docs/translations/README.ps.md
@@ -25,7 +25,7 @@
 
 ## دا ذخیره (repository) فورک کړئ
 
-<img align="left" width="300" src="https://firstcontributions.github.io/assets/Readme/fork.png" alt="fork this repository" />
+<img align="left" width="300" src="https://firstcontributions.github.io/assets/Readme/fork.png" alt="د دې زیرمې فورک کول" />
 
 - د دې پاڼې په سر کې د Fork تڼۍ کلیک کړئ.
 - فورک کول به د دې ذخیرې یوه کاپي ستاسو د GitHub اکاونټ ته انتقال کړي.
@@ -34,7 +34,7 @@
 
 ## دا ذخیره (repository) کلون کړئ
 
-<img align="left" width="300" src="https://firstcontributions.github.io/assets/Readme/clone.png" alt="clone this repository" />
+<img align="left" width="300" src="https://firstcontributions.github.io/assets/Readme/clone.png" alt="د دې زیرمې کلون کول" />
 
 - خپل اکاونټ ته لاړ شئ او د فورک شوې ذخیرې لینک د **Code** تڼۍ څخه کاپي کړئ.
 
@@ -64,7 +64,7 @@ your-branch-name ستاسو د څانګې نوم دی. کولای شئ چې هر
 - د `Contributors.md` فایل خلاص کړئ او خپل نوم پکې اضافه کړئ کې).
 - فایل ذخیره کړئ.
 
-<img align="left" width="450" src="https://firstcontributions.github.io/assets/Readme/git-status.png" alt="git status" />
+<img align="left" width="450" src="https://firstcontributions.github.io/assets/Readme/git-status.png" alt="د Git حالت" />
 
 - ترمینل ته لاړ شئ او دا کمانډ اجرا کړئ ترڅو وګورئ کوم فایلونه مو بدل کړي دي:
 


### PR DESCRIPTION
This pull request translates the English alt text of images in the README.ps.md file to turkish to improve accessibility for turkish - speaking users. 

Changes made:
- Updated alt text for the "fork this repository" image.
- Updated alt text for the "clone this repository" image.
- Updated alt text for the "git status" image.

No functional code changes were made. This is purely a documentation update.
