### PR TITLE
update on possible solution on ISSUE_TEMPLATE.md

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -10,7 +10,7 @@
 
 💡 **Possible solutions**
 <!--- Not obligatory, but suggest an idea for implementing addition or change -->
-
+-> If you're using VS code may be the .md files unable to load the solution to disable the extensions and then check again.
 📋  **Steps to solve the problem**
 
 *   Comment below about what you've started working on.

--- a/Contributors.md
+++ b/Contributors.md
@@ -1243,6 +1243,7 @@ geogjegjegoiejgeroigjergjeoi
 - [Christian Luis] (https://github.com/christianLuis07)
 - [Ryan Kimutai](https://github.com/Ryank-80) -[Aloysius Owili](https://github.com/360koalabear) -[Shahryar Sohail](https://github.com/shahryar-sohail) -[Udhaya parameshwaran](https://github.com/UdhayaParameshwaran-ai) -[Emma Yu](https://github.com/jjy88)
 - Yashwanth
+- [prem kumar grk](https://github.com/premkumargrk)
 - [Ryan Kimutai](https://github.com/Ryank-80)
 - [Aloysius Owili](https://github.com/360koalabear)
 - [Shahryar Sohail](https://github.com/shahryar-sohail)


### PR DESCRIPTION
If you are using VS Code and your .md (Markdown) files are not opening or appear completely blank, the issue may be caused by a malfunctioning extension.

This problem prevents Markdown files such as README.md, Contributors.md, from loading correctly.

### Steps to Fix

1.Click the extension on the left panel. 
2. on the extension option on top of the right side, view and more tools. 
3. Select it -- Disable All Installed Extensions.
4. Now try opening the `.md` file again  

### Why This Works

If the Markdown file opens correctly after disabling extensions, the issue was caused by a conflicting or broken extension (such as **Markdown All in One**, **GitLens**, **Prettier**, etc.).
