### PR TITLE
Fix hyperlinks within HTML <pre> tag in Ecuadorian Spanish translation

### DIFF
--- a/docs/translations/README.ec.md
+++ b/docs/translations/README.ec.md
@@ -102,8 +102,8 @@ Reemplaza `<nombre-rama>` con el nombre de la rama que creaste anteriormente.
 
 - ### Error de Autenticación
     <pre>remote: El soporte para la autenticación de contraseña se eliminó el 13 de agosto de 2021. Utiliza un token de acceso personal en su lugar.
-  remote: Consulta [https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/](https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/) para obtener más información.
-  fatal: Fallo en la autenticación para '[https://github.com/](https://github.com/)<tu-usuario>/first-contributions.git/'</pre>
+  remote: Consulta https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/ para obtener más información.
+  fatal: Fallo en la autenticación para 'https://github.com/<tu-usuario>/first-contributions.git/'</pre>
     Ve al [tutorial de GitHub](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account) sobre cómo generar y configurar una clave SSH en tu cuenta.
 
     Además, es posible que desees ejecutar `git remote -v` para verificar tu dirección remota.


### PR DESCRIPTION
Fixes #107871

Replaces markdown hyperlink syntax within <pre> tags with plain URLs to display correctly.

Before submitting this pull request, check the changes to see it's only the changes you made intentionally
If there are changes to other lines you didn't make deliberately, it's possible that your IDE made the changes with a utility like prettier.
Next time, make sure that you only add your changes by using `git add -p` and rather than `git add Contributors.md`

If you're doing something in the checklist below, put an `x` inside `[ ]` so that `- [ ]` becomes `- [x]`

- [ ] I had fun going through this tutorial (ノ^o^)ノ and learned on the way ٩(＾◡＾)۶
- [ ] There are some things I'd like to improve in this tutorial. I have written them below.
- [ ] There were steps where I had errors while following this tutorial. I have written them below.