### PR TITLE
Translate English alt text to Catalan in README.ca.md

### DIFF
--- a/docs/translations/README.ca.md
+++ b/docs/translations/README.ca.md
@@ -63,7 +63,7 @@ git checkout -b add-nom-cognom
 
 Obre l'arxiu `Contributors.md` en un editor de text i afegeix-hi el teu nom. No l'afegeixis ni al principi, ni al final de l'arxiu. Posa'l en qualsevol altre posició. Llavors desa l'arxiu.
 
-<img align="right" width="450" src="https://firstcontributions.github.io/assets/Readme/git-status.png" alt="git status" />
+<img align="right" width="450" src="https://firstcontributions.github.io/assets/Readme/git-status.png" alt="estat del git" />
 
 
 Ara, si vas al directori del projecte i executes el comandament `git status`, veuràs els canvis.


### PR DESCRIPTION
## Summary
This PR translates the English alt text attribute to Catalan for the git-status.png image in the Catalan README translation file.

## Changes Made
- Changed `alt="git status"` to `alt="estat del git"` on line 66 of `docs/translations/README.ca.md`

## Why This Change
This improves accessibility for Catalan speakers who use screen readers or other assistive technologies. Having alt text in the user's native language provides a better experience.

## Related Issue
Resolves #105356

- [x] I had fun going through this tutorial and learned on the way!