### PR TITLE
fix: hyperlinks inside <pre> block in README.ec.md

### DIFF
--- a/docs/translations/README.ec.md
+++ b/docs/translations/README.ec.md
@@ -102,15 +102,10 @@ Reemplaza `<nombre-rama>` con el nombre de la rama que creaste anteriormente.
 
 - ### Error de Autenticación
     <pre>remote: El soporte para la autenticación de contraseña se eliminó el 13 de agosto de 2021. Utiliza un token de acceso personal en su lugar.
-  remote: Consulta [https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/](https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/) para obtener más información.
-  fatal: Fallo en la autenticación para '[https://github.com/](https://github.com/)<tu-usuario>/first-contributions.git/'</pre>
-    Ve al [tutorial de GitHub](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account) sobre cómo generar y configurar una clave SSH en tu cuenta.
-
-    Además, es posible que desees ejecutar `git remote -v` para verificar tu dirección remota.
-    
-    Si se ve algo como esto:
-    <pre>origin https://github.com/tu-usuario/tu_repo.git (fetch)
-origin  https://github.com/tu-usuario/tu_repo.git (push)</pre>
+  remote: Consulta https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/ para obtener más información.
+fatal: Fallo en la autenticación para 'https://github.com/<tu-usuario>/first-contributions.git/'
+<pre>origin https://github.com/tu-usuario/tu_repo.git (fetch)
+origin https://github.com/tu-usuario/tu_repo.git (push)</pre>
 
 
     

--- a/docs/translations/README.ec.md
+++ b/docs/translations/README.ec.md
@@ -104,13 +104,7 @@ Reemplaza `<nombre-rama>` con el nombre de la rama que creaste anteriormente.
     <pre>remote: El soporte para la autenticación de contraseña se eliminó el 13 de agosto de 2021. Utiliza un token de acceso personal en su lugar.
   remote: Consulta https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/ para obtener más información.
 fatal: Fallo en la autenticación para 'https://github.com/<tu-usuario>/first-contributions.git/'
-<pre>origin https://github.com/tu-usuario/tu_repo.git (fetch)
-origin https://github.com/tu-usuario/tu_repo.git (push)</pre>
 
-
-    
-    cámbialo usando este comando:
-    ```bash
     git remote set-url origin git@github.com:tu-usuario/tu_repo.git
     ```
     De lo contrario, aún se te pedirá un nombre de usuario y contraseña y obtendrás un error de autenticación.

--- a/docs/translations/README.ec.md
+++ b/docs/translations/README.ec.md
@@ -109,8 +109,9 @@ Reemplaza `<nombre-rama>` con el nombre de la rama que creaste anteriormente.
     Además, es posible que desees ejecutar `git remote -v` para verificar tu dirección remota.
     
     Si se ve algo como esto:
-    <pre>origin [https://github.com/tu-usuario/tu_repo.git] (fetch)  
-  origin  [https://github.com/tu-usuario/tu_repo.git] (push)</pre>
+    <pre>origin https://github.com/tu-usuario/tu_repo.git (fetch)
+origin  https://github.com/tu-usuario/tu_repo.git (push)</pre>
+
 
     
     cámbialo usando este comando:


### PR DESCRIPTION
Resolves #107871

Replace Markdown-style hyperlinks inside <pre> blocks with raw URLs so the error snippet displays correctly.
