### PR TITLE
Added accessibility note for Persian translation testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Open Source Helpers](https://www.codetriage.com/roshanjossey/first-contributions/badges/users.svg)](https://www.codetriage.com/roshanjossey/first-contributions)
 
 #### _Read this in [other languages](docs/translations/Translations.md)._
+> **Note:** Added an accessibility note for Persian translation testing.
 <kbd>[<img title="Shqip" alt="Shqip" src="https://cdn.statically.io/gh/hjnilsson/country-flags/master/svg/al.svg" width="22">](docs/translations/README.al.md)</kbd>
 <kbd>[<img title="Armenian" alt="Armenian" src="https://cdn.statically.io/gh/hjnilsson/country-flags/master/svg/am.svg" width="22">](docs/translations/README.arm.md)</kbd>
 <kbd>[<img title="Uzbek" alt="Uzbek language" src="https://cdn.statically.io/gh/hjnilsson/country-flags/master/svg/uz.svg" width="22">](docs/translations/README.uz.md)</kbd>


### PR DESCRIPTION
This update adds a short accessibility note to the Persian translation section of the README. The goal is to improve clarity for contributors who need additional guidance when reviewing or testing translated text. The note follows the project’s documentation style and supports contributors who may rely on screen readers or need clearer instructions while navigating translation workflows.