### PR TITLE
docs: translate badge alt texts to Ewe in README.ewe.md

### DIFF
--- a/docs/translations/README.ewe.md
+++ b/docs/translations/README.ewe.md
@@ -1,6 +1,6 @@
 [![kɔmpiutaɖoɖo femaxee ƒe Lɔlɔ̃](https://badges.frapsoft.com/os/v1/open-source.svg?v=103)](https://github.com/ellerbrock/open-source-badges/)
-[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
-[![Open Source Helpers](https://www.codetriage.com/roshanjossey/first-contributions/badges/users.svg)](https://www.codetriage.com/roshanjossey/first-contributions)
+[![Mɔɖeɖe: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
+[![kɔmpiutaɖoɖo femaxee Kpekpeɖeŋunalawo](https://www.codetriage.com/roshanjossey/first-contributions/badges/users.svg)](https://www.codetriage.com/roshanjossey/first-contributions)
 
 
 # Kpekpeɖeŋu Gbãtɔ


### PR DESCRIPTION
Addresses #105340
- [x] I had fun going through this tutorial (ノ^o^)ノ and learned on the way ٩(＾◡＾)۶
- [ ] There are some things I'd like to improve in this tutorial. I have written them below.
- [ ] There were steps where I had errors while following this tutorial. I have written them below.
## Changes
Translated the following English alt texts to Ewe in `docs/translations/README.ewe.md`:
- `License: MIT` -> `Mɔɖeɖe: MIT`
- `Open Source Helpers` -> `kɔmpiutaɖoɖo femaxee Kpekpeɖeŋunalawo`
