### PR TITLE
docs: add missing code contributions link to Esperanto README

### DIFF
--- a/docs/translations/README.eo.md
+++ b/docs/translations/README.eo.md
@@ -119,6 +119,7 @@ Gratulojn! Vi ĵus finis la regulan _fork -> clone -> redaktu -> pull request_ f
 
 Festu vian kontribuon kaj dividiĝu kun viaj amikoj kaj sekvantoj irante al [rete apikaĵo](https://firstcontributions.github.io/#social-share).
 
+Se vi deziras pli da praktikado, rigardu [kodajn kontribuojn](https://github.com/roshanjossey/code-contributions).
 
 Nun komencu kontribui al aliaj projektoj. Ni kolektis liston de projektoj kun facilaj problemoj, por ke vi povu ekhavi. Rigardu [la liston de projektoj en la rete apikaĵo](https://firstcontributions.github.io/#project-list).
 


### PR DESCRIPTION
Addresses #104244
The Slack link was already removed in a previous commit (#104261), but the replacement link to code contributions was missing.
This PR adds the missing sentence:
"Se vi deziras pli da praktikado, rigardu [kodajn kontribuojn](https://github.com/roshanjossey/code-contributions)."

- [x ] I had fun going through this tutorial (ノ^o^)ノ and learned on the way ٩(＾◡＾)۶
- [ ] There are some things I'd like to improve in this tutorial. I have written them below.
- [ ] There were steps where I had errors while following this tutorial. I have written them below.