### PR TITLE
Fix grammar: command-line usage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@
 
 This project aims to simplify and guide the way beginners make their first contribution. If you are looking to make your first contribution, follow the steps below.
 
-_If you're not comfortable with command line, [here are tutorials using GUI tools.](#tutorials-using-other-tools)_
+_If you're not comfortable with command-line, [here are tutorials using GUI tools.](#tutorials-using-other-tools)_
 
 <img align="right" width="300" src="https://firstcontributions.github.io/assets/Readme/fork.png" alt="fork the repository" />
 


### PR DESCRIPTION
This PR fixes a minor grammar issue by using the correct compound adjective "command-line" in the README.
