### PR TITLE
docs: fix markdown spacing in Contributors.md

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -1,14 +1,14 @@
 # Contributors
--[soner](https://github.com/C8338Soner/first-contributions)
+- [soner](https://github.com/C8338Soner/first-contributions)
 
 - [🔗 Armaan Singh Klair](https://github.com/ArmaanSinghKlair)
-- [Ayush Rusiya] (https://github.com/ayushrusiya9)
+- [Ayush Rusiya](https://github.com/ayushrusiya9)
 - [Asad Khalid](https://github.com/Asad-K2025)
-- [Pranab Tiwari] (https://github.com/pranabtiwari)
-- [Khushi Jaiswal] (https://github.com/Khushi84670/)
-- [Ch Vipulabhiram] (https://github.com/Vipulabhiram)
-- [Ashad Shaikh] (https://github.com/senku0-0)
-- [Keerthan Jakkaraju](https://github.com/Keerthanjakkarajucodes)git sta
+- [Pranab Tiwari](https://github.com/pranabtiwari)
+- [Khushi Jaiswal](https://github.com/Khushi84670/)
+- [Ch Vipulabhiram](https://github.com/Vipulabhiram)
+- [Ashad Shaikh](https://github.com/senku0-0)
+- [Keerthan Jakkaraju](https://github.com/Keerthanjakkarajucodes)
 - [Anshul Bhardwaj](https://github.com/Anshul-Bhardwaj-21)
 - [Anurag Banerjee](https://github.com/Banerjee2027)
 - [Jocin J] (https://github.com/Jocin55)


### PR DESCRIPTION
Fixes inconsistent markdown spacing and removes a stray word near the top of Contributors.md.

Changes:
- Fixed spacing in markdown links (e.g., `] (` → `](`)
- Removed stray text "git sta"

This change only adjusts formatting. No contributor entries were removed or altered.