### PR TITLE
Remove slack link in Filipino translation

### DIFF
--- a/docs/translations/README.fil.md
+++ b/docs/translations/README.fil.md
@@ -120,6 +120,8 @@ Congrats! Nakumpleto mo lang ang karaniwang _fork -> clone -> edit -> pull reque
 
 Ipakita ang iyong kontribusyon sa iyong mga kaibigan at tagasubaybay at magpunta sa [web app](https://firstcontributions.github.io/#social-share).
 
+Kung gusto mo pang magsanay, tingnan ang [code contributions](https://github.com/roshanjossey/code-contributions).
+
 Ngayon, pwede ka nang gumawa ng kontribusyon sa iba pang mga proyekto! Gumawa kami ng isang listahan ng mga proyekto na may mga madadaling gawing _issues_ na pwede mong gawin. Tingnan ang [listahan ng mga proyekto sa web app](https://firstcontributions.github.io/#project-list).
 
 ### [Karagdagang materyal](additional-material/git_workflow_scenarios/additional-material.md)


### PR DESCRIPTION
﻿## Summary
- Update Filipino translation section ""Saan na pagkatapos?""
- Add code contributions link to match main README direction

## Validation
- Verified target file: docs/translations/README.fil.md
- Confirmed code contributions link is present in the target section

Addresses #104248
