### PR TITLE
Remove slack link in Irish translation

### DIFF
--- a/docs/translations/README.ga.md
+++ b/docs/translations/README.ga.md
@@ -135,7 +135,7 @@ Comhghairdeas! Chríochnaigh tú an tslí ríthábhachtach  _fork -> clone -> ed
 
 Ceiliúraigh do chionta agus roinne é le do chairde agus le do leanúnaigh trí dul go dtí an aip ghréasáin. [web app](https://firstcontributions.github.io/#social-share).
 
-Más mian leat níos mó cleachtas, seiceáil. [code contributions](https://roshanjossey.github.io/code-contributions/).
+Más mian leat níos mó cleachtas, seiceáil. [code contributions](https://github.com/roshanjossey/code-contributions).
 
 
 Anois, lig dúinn tú a thosú ag tacú le tionscadail eile. Tá liosta againn de thionscadail le faidhéideanna éasca a d'fhéadfá tosú orthu. Féach ar liosta na dtionscadal san aip ghréasáin.


### PR DESCRIPTION
﻿## Summary
- Update Irish translation "code contributions" link in README.ga.md
- Replace legacy pages URL with repository URL to match issue guidance

## Validation
- Verified target line in docs/translations/README.ga.md
- Confirmed link now points to https://github.com/roshanjossey/code-contributions

Addresses #104250
