### PR TITLE
Remove slack link in Romanian translation

### DIFF
--- a/docs/translations/README.ro.md
+++ b/docs/translations/README.ro.md
@@ -122,7 +122,7 @@ Felicitări! Ați finalizat fluxul standard _fork -> clone -> edit -> pull reque
 
 Sărbătoriți-vă contribuția și partajați-o cu prietenii și urmăritorii dvs., accesând [aplicația web](https://firstcontributions.github.io/#social-share).
 
-Puteți să vă alăturați echipei noastre Slack dacă aveți nevoie de ajutor sau aveți întrebări. [Alăturați-vă echipei Slack](https://join.slack.com/t/firstcontributors/shared_invite/zt-1n4y7xnk0-DnLVTaN6U9xLU79H5Hi62w).
+Dacă doriți mai multă practică, consultați [code contributions](https://github.com/roshanjossey/code-contributions).
 
 Acum să vă începem cu contribuția la alte proiecte. Am compilat o listă de proiecte cu probleme ușoare cu care puteți începe. Verificați [lista de proiecte din aplicația web](https://firstcontributions.github.io/#project-list).
 


### PR DESCRIPTION
﻿## Summary
- Remove Slack link in Romanian translation
- Add code contributions link in the "Where to go from here" section

## Validation
- Verified target file: docs/translations/README.ro.md
- Confirmed Slack link replaced with code contributions repository URL

Addresses #104792
