### PR TITLE
Remove slack link in Norwegian translation

### DIFF
--- a/docs/translations/README.no.md
+++ b/docs/translations/README.no.md
@@ -1,5 +1,4 @@
 [![Open Source Love](https://firstcontributions.github.io/open-source-badges/badges/open-source-v1/open-source.svg)](https://github.com/firstcontributions/open-source-badges)
-[<img align="right" width="150" src="https://firstcontributions.github.io/assets/Readme/join-slack-team.png">](https://join.slack.com/t/firstcontributors/shared_invite/zt-1n4y7xnk0-DnLVTaN6U9xLU79H5Hi62w)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 [![Open Source Helpers](https://www.codetriage.com/roshanjossey/first-contributions/badges/users.svg)](https://www.codetriage.com/roshanjossey/first-contributions)
 
@@ -137,7 +136,7 @@ Gratulerer! Du har gjennomført standardprosessen for _fork -> clone -> edit -> 
 
 Feir ditt bidrag og del det med dine venner og følgere ved å gå til [web app](https://firstcontributions.github.io/#social-share).
 
-Behøver du hjelp eller vil stille spørsmål så kan du bli med i vår slack-gruppe. [Join slack team](https://join.slack.com/t/firstcontributors/shared_invite/zt-1hg51qkgm-Xc7HxhsiPYNN3ofX2_I8FA).
+Hvis du vil ha mer øvelse, sjekk [code contributions](https://github.com/roshanjossey/code-contributions).
 
 Nå kan du gå videre og bidra til andre open-source prosjekter. Vi har satt sammen en liste med enkle og overkommelige problemer du kan starte med. Sjekk den ut her: [the list of projects in the web app](https://firstcontributions.github.io/#project-list).
 <br/><br/>


### PR DESCRIPTION
﻿## Summary
- Remove remaining Slack links from Norwegian translation README
- Replace the "Where to go from here" Slack line with code contributions repository link

## Validation
- Verified target file: docs/translations/README.no.md
- Confirmed no slack link remains in this file

Addresses #104786
