### PR TITLE
Remove slack link in Dutch translation

### DIFF
--- a/docs/translations/README.nl.md
+++ b/docs/translations/README.nl.md
@@ -1,5 +1,4 @@
 [![Open Source Love](https://firstcontributions.github.io/open-source-badges/badges/open-source-v1/open-source.svg)](https://github.com/firstcontributions/open-source-badges)
-[<img align="right" width="150" src="https://firstcontributions.github.io/assets/Readme/join-slack-team.png">](https://join.slack.com/t/firstcontributors/shared_invite/zt-1n4y7xnk0-DnLVTaN6U9xLU79H5Hi62w)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 [![Open Source Helpers](https://www.codetriage.com/roshanjossey/first-contributions/badges/users.svg)](https://www.codetriage.com/roshanjossey/first-contributions)
 
@@ -123,7 +122,7 @@ Gefeliciteerd! Je hebt zojuist de standaard _fork -> clone -> edit -> PR_ workfl
 
 Vier je bijdrage en deel het met je vrienden en volgers via de [web app](https://firstcontributions.github.io/#social-share).
 
-Mocht je nog vragen of hulp nodig hebben dan kun je je aanmelden voor ons [Slack team](https://join.slack.com/t/firstcontributors/shared_invite/zt-1hg51qkgm-Xc7HxhsiPYNN3ofX2_I8FA).
+Wil je meer oefenen, bekijk dan [code contributions](https://github.com/roshanjossey/code-contributions).
 
 Laten we je nu op weg helpen met het bijdragen aan andere projecten. We hebben een lijst samengesteld met projecten die makkelijke issues bevatten waar je aan kunt werken. Bekijk [de lijst op de web app](https://firstcontributions.github.io/#project-list)
 


### PR DESCRIPTION
﻿## Summary
- Remove remaining Slack links from Dutch translation README
- Replace the "How now further?" section Slack sentence with code contributions repository link

## Validation
- Verified target file: docs/translations/README.nl.md
- Confirmed no slack link remains in this file

Addresses #104785
