### PR TITLE
fix: Remove slack link in Romanian translation (#104792)

### DIFF
--- a/docs/translations/README.ma.md
+++ b/docs/translations/README.ma.md
@@ -9,7 +9,7 @@
 Fo9ma katbghi tbda chi 7aja jdida katkoun m39da flewl. Dik lkhouf anak tghlet ki3ssbek,5ossosan fach katkoun 5dam m3a nass o5rin. Walakin lblan dl open source w anak t5dm m3a nass f fra9i . Bghina , nsshlou 3likoum bach t3lmou tcharkou fchi projet open source b7al hada l awel mra .   
 
 Rah blan tb9a t9ra kifach dir wla tchouf des tutoriels , walakin wach machi 7ssen nwriwk ki der bla matghlet ? Had lprojet l hadaf dyalou howa y3tek nassa2i7 w 5lik 3a9l : koulma knti mheden , ghat3lem 7ssen. Ila knti 3wal der awel i3ana , tbe3 had l5otowat w ra atsde9lk . Kanwa3dk , ghay3jbek l7al.
-<img align="right" width="300" src="https://firstcontributions.github.io/assets/Readme/fork.png" alt="connecter had repo" />
+<img align="right" width="300" src="https://firstcontributions.github.io/assets/Readme/fork.png" alt="forki had repo" />
 
 Ila makanch 3ndk git f pc dyalk, [ Telechargeh ]( https://help.github.com/articles/set-up-git/ )mn had site.
 
@@ -19,7 +19,7 @@ Brek 3la dik FORK kima kaybanlk f tswira bach twli 3ndek b7al version dyal repo 
 
 ## Telecharger 3ndk repo (Kismiwha clone )
 
-<img align="right" width="300" src="https://firstcontributions.github.io/assets/Readme/clone.png" alt="Clone d repo" />
+<img align="right" width="300" src="https://firstcontributions.github.io/assets/Readme/clone.png" alt="telcharge had repo" />
 
 Daba ,cloner repo dyalk l pc 3ndk. Brek 3la bottona d Clone w copier dik lien (HTTPS houwa sahel) ra kayna bottona 7da lien katcopiehlk nichan .
 
@@ -30,7 +30,7 @@ git clone "dik lien li 3ad copieti"
 ```
 3andak t5liha hakak hhh "dik lien li 3ad copieti" (bla douk "") kteb tma lien li copieti fhemni . 
 
-<img align="right" width="300" src="https://firstcontributions.github.io/assets/Readme/copy-to-clipboard.png" alt="copier l'URL dans le presse-papier" />
+<img align="right" width="300" src="https://firstcontributions.github.io/assets/Readme/copy-to-clipboard.png" alt="kopi l'URL" />
 
 Atkoun b7al had chkel :
 ```bash
@@ -83,11 +83,11 @@ ana knt mssmiha add-brahim , nta bdlha bachma knti dayr .
 Ila rj3ti l github atl9a dik l3iba dyal `Compare & pull request`
 brek 3liha a5ay.
 
-<img style="float: right;" src="https://firstcontributions.github.io/assets/Readme/compare-and-pull.png" alt="khdm create pull request" />
+<img style="float: right;" src="https://firstcontributions.github.io/assets/Readme/compare-and-pull.png" alt="khdam pull request" />
 
 Sf brek 3liha bach tle3 lnass li mss2oulin 3la hadchi.
 
-<img style="float: right;" src="https://firstcontributions.github.io/assets/Readme/submit-pull-request.png" alt="Kheddem submit pull request" />
+<img style="float: right;" src="https://firstcontributions.github.io/assets/Readme/submit-pull-request.png" alt="b3at pull request" />
 
 Chwia mbe3d matjm3 dik lmodifications li derti . Aywslk mail ki9ololk fih ra safi dkchi dyalk nadi.
 

--- a/docs/translations/README.ma.md
+++ b/docs/translations/README.ma.md
@@ -83,11 +83,11 @@ ana knt mssmiha add-brahim , nta bdlha bachma knti dayr .
 Ila rj3ti l github atl9a dik l3iba dyal `Compare & pull request`
 brek 3liha a5ay.
 
-<img style="float: right;" src="https://firstcontributions.github.io/assets/Readme/compare-and-pull.png" alt="create a pull request" />
+<img style="float: right;" src="https://firstcontributions.github.io/assets/Readme/compare-and-pull.png" alt="khdm create pull request" />
 
 Sf brek 3liha bach tle3 lnass li mss2oulin 3la hadchi.
 
-<img style="float: right;" src="https://firstcontributions.github.io/assets/Readme/submit-pull-request.png" alt="submit pull request" />
+<img style="float: right;" src="https://firstcontributions.github.io/assets/Readme/submit-pull-request.png" alt="Kheddem submit pull request" />
 
 Chwia mbe3d matjm3 dik lmodifications li derti . Aywslk mail ki9ololk fih ra safi dkchi dyalk nadi.
 

--- a/docs/translations/README.ro.md
+++ b/docs/translations/README.ro.md
@@ -1,5 +1,4 @@
 [![Surse Deschise Love](https://badges.frapsoft.com/os/v1/open-source.svg?v=103)](https://github.com/ellerbrock/open-source-badges/)
-[<img align="right" width="150" src="https://firstcontributions.github.io/assets/Readme/join-slack-team.png">](https://join.slack.com/t/firstcontributors/shared_invite/zt-1hg51qkgm-Xc7HxhsiPYNN3ofX2_I8FA)
 [![Licență: MIT](https://img.shields.io/badge/Licență-MIT-green)](https://opensource.org/licenses/MIT)
 [![Contribuitori](https://www.codetriage.com/roshanjossey/first-contributions/badges/users.svg)](https://www.codetriage.com/roshanjossey/first-contributions)
 
@@ -122,7 +121,7 @@ Felicitări! Ați finalizat fluxul standard _fork -> clone -> edit -> pull reque
 
 Sărbătoriți-vă contribuția și partajați-o cu prietenii și urmăritorii dvs., accesând [aplicația web](https://firstcontributions.github.io/#social-share).
 
-Puteți să vă alăturați echipei noastre Slack dacă aveți nevoie de ajutor sau aveți întrebări. [Alăturați-vă echipei Slack](https://join.slack.com/t/firstcontributors/shared_invite/zt-1n4y7xnk0-DnLVTaN6U9xLU79H5Hi62w).
+Puteți să vă alăturați echipei noastre Slack dacă aveți nevoie de ajutor sau aveți întrebări. [Alăturați-vă echipei code contributions](https://roshanjossey.github.io/code-contributions/).
 
 Acum să vă începem cu contribuția la alte proiecte. Am compilat o listă de proiecte cu probleme ușoare cu care puteți începe. Verificați [lista de proiecte din aplicația web](https://firstcontributions.github.io/#project-list).
 

--- a/docs/translations/README.tn.md
+++ b/docs/translations/README.tn.md
@@ -75,7 +75,7 @@ git checkout -b your-new-branch-name
 
 Tw 7el el file `Contributors.md` fil editor, zid ismek fiha. Mat7otoch milowel wala filo5er mta3 el file. 7ot fi plasa fil west. Tw, a3melo save.
 
-<img align="right" width="450" src="https://firstcontributions.github.io/assets/Readme/git-status.png" alt="git status" />
+<img align="right" width="450" src="https://firstcontributions.github.io/assets/Readme/git-status.png" alt="statut git" />
 
 Ken temchi lil directory mta3 repo wtekteb el command `git status`, tw tchof fama changements saret.
 
@@ -127,7 +127,7 @@ Badel `your-branch-name` bi isem lbranch l3meltha se3a.
 
 Ken temchi lil repo mte3ek 3al github, tw  tchof button `Compare & pull request`. Enzel 3lih.
 
-<img style="float: right;" src="https://firstcontributions.github.io/assets/Readme/compare-and-pull.png" alt="creation pull request" />
+<img style="float: right;" src="https://firstcontributions.github.io/assets/Readme/compare-and-pull.png" alt="sna3 pull request" />
 
 Tw a3mel sumbit lil pull request.
 

--- a/docs/translations/README.tn.md
+++ b/docs/translations/README.tn.md
@@ -9,7 +9,7 @@ awel contribution ta3melha 3al github bch tkon pratique tjareb wtchof kolchy b3i
 
 _Ken mat7ebech tesa3mel el cmd, [hedhom tutorials o5rin testa3mel fihom des logiciles.](#tutorials-using-other-tools)_
 
-<img align="right" width="300" src="https://firstcontributions.github.io/assets/Readme/fork.png" alt="fork this repository" />
+<img align="right" width="300" src="https://firstcontributions.github.io/assets/Readme/fork.png" alt="forki had repo" />
 
 #### Edhaken moch sabeb git 3andek fil pc, [sobo mil lien hedha](https://docs.github.com/en/get-started/quickstart/set-up-git).
 
@@ -20,7 +20,7 @@ Haka iwali 3andek copie f compte mt3ek tejem tebedel fiha kima t7eb.
 
 ## Cloni el repo
 
-<img align="right" width="300" src="https://firstcontributions.github.io/assets/Readme/clone.png" alt="clone this repository" />
+<img align="right" width="300" src="https://firstcontributions.github.io/assets/Readme/clone.png" alt="cloni had repo" />
 
 Tw cloni el repo li 3meltelha fork lil machine mte3ek. Imchi lil compte github 7el el forked repo inzel 3al button "code" b3d el ssh b3d copi lien el mawjoud.
 
@@ -127,11 +127,11 @@ Badel `your-branch-name` bi isem lbranch l3meltha se3a.
 
 Ken temchi lil repo mte3ek 3al github, tw  tchof button `Compare & pull request`. Enzel 3lih.
 
-<img style="float: right;" src="https://firstcontributions.github.io/assets/Readme/compare-and-pull.png" alt="create a pull request" />
+<img style="float: right;" src="https://firstcontributions.github.io/assets/Readme/compare-and-pull.png" alt="creation pull request" />
 
 Tw a3mel sumbit lil pull request.
 
-<img style="float: right;" src="https://firstcontributions.github.io/assets/Readme/submit-pull-request.png" alt="submit pull request" />
+<img style="float: right;" src="https://firstcontributions.github.io/assets/Readme/submit-pull-request.png" alt="b3at pull request" />
 
 3ala 9rib tw na3mel merge lil les changements mete3ek lil main branch mta3 lprojet hedha. Tw tjik notification email ki tsir merge lil les changements.
 


### PR DESCRIPTION
## Summary

Removed the outdated Slack team invitation link from the Romanian translation README:

1. **Removed slack image link** at the top of the README (line 2)
2. **Replaced slack text link** with a link to the code contributions repository

This addresses issue #104792 as the project is moving away from using Slack.

## Changes Made

- Modified: 
- Removed: Slack image link
- Updated: Slack text link → code contributions link

## Testing

- Verified changes locally
- No functionality broken, only removed outdated external link

---

Addresses #104792