### PR TITLE
docs(pt-ao): remove outdated Slack links and add code-contributions path

### DIFF
--- a/docs/translations/README.pt-ao.md
+++ b/docs/translations/README.pt-ao.md
@@ -1,5 +1,4 @@
 [![Open Source Love](https://badges.frapsoft.com/os/v1/open-source.svg?v=103)](https://github.com/ellerbrock/open-source-badges/)
-[<img align="right" width="150" src="https://firstcontributions.github.io/assets/Readme/join-slack-team.png">](https://join.slack.com/t/firstcontributors/shared_invite/zt-1hg51qkgm-Xc7HxhsiPYNN3ofX2_I8FA)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 [![Open Source Helpers](https://www.codetriage.com/roshanjossey/first-contributions/badges/users.svg)](https://www.codetriage.com/roshanjossey/first-contributions)
 
@@ -83,7 +82,7 @@ Quando puder incorporarei as tuas mudanças no Branch principal (master) deste p
 
 Partilhe com seus amigos e seguidores [web app](https://firstcontributions.github.io/#social-share).
 
- Podes também juntar-te à nossa equipa no Slack caso precises de alguma ajuda ou tenhas alguma dúvida. [Junta-te à nossa equipa no Slack](https://join.slack.com/t/firstcontributors/shared_invite/zt-1hg51qkgm-Xc7HxhsiPYNN3ofX2_I8FA).
+Se quiseres praticar mais, consulta [code contributions](https://github.com/roshanjossey/code-contributions).
 
 Aqui tens mais suguestões para a sua próxima contribuição, Baza lá dar uma olhada:
 


### PR DESCRIPTION
## What this PR changes
- Removes the Slack badge/link from `docs/translations/README.pt-ao.md`
- Replaces the Slack invitation with a `code-contributions` link

## Why
The repository is phasing out Slack references in translation docs. This keeps the Portuguese (Angola) README aligned with the current contributor path.

## Scope
- Single-file docs update
- No code changes
