### PR TITLE
docs(hu): replace outdated Slack reference with code-contributions

### DIFF
--- a/docs/translations/README.hu.md
+++ b/docs/translations/README.hu.md
@@ -110,7 +110,7 @@ Gratulálunk! Sikeresen teljesítetted az alapvető _fork -> clone -> edit -> PR
 
 Ünnepeld meg az első kooperációdat és oszd meg barátaiddal és követőiddel ennek a [web app](https://firstcontributions.github.io/#social-share)-nak a segítségével.
 
-Bármilyen kérdésed van vagy segítségre lenne szükséged, csatlakozz slack csapatunkhoz. [Csatlakozz a slack csapathoz.](https://join.slack.com/t/firstcontributors/shared_invite/zt-1hg51qkgm-Xc7HxhsiPYNN3ofX2_I8FA).
+Ha többet szeretnél gyakorolni, nézd meg a [code contributions](https://github.com/roshanjossey/code-contributions) repót.
 
 Itt az idő egy másik projektben is közreműködni. Összeállítottunk egy listát azokról a projektekről, melyek könnyebb feladatokat tartalmaznak az induláshoz. Nézd meg a [projektek listáját](https://firstcontributions.github.io/#project-list) a webalkalmazásban.
 


### PR DESCRIPTION
## What this PR changes
- Replaces the outdated Slack call-to-action in `docs/translations/README.hu.md`
- Points contributors to the active `code-contributions` repository

## Why
The project no longer uses Slack as the primary path for new contributors in translations. This keeps the Hungarian README consistent with the current flow.

## Scope
- One-file documentation update
- No code/build changes
