### PR TITLE
docs(it): replace obsolete Slack invitation with code-contributions

### DIFF
--- a/docs/translations/README.it.md
+++ b/docs/translations/README.it.md
@@ -112,7 +112,7 @@ Presto saranno incorporati (*merge*) tutti i tuoi cambiamenti nel master branch 
 
 ## E ora?
 
-Unisciti alla nostra squadra su slack in caso tu abbia bisogno di aiuto o abbia qualche domanda. Proveremo ad aiutarti! [Unisciti alla squadra Slack](https://join.slack.com/t/firstcontributors/shared_invite/zt-1hg51qkgm-Xc7HxhsiPYNN3ofX2_I8FA).
+Se vuoi fare più pratica, dai un'occhiata al repository [code contributions](https://github.com/roshanjossey/code-contributions).
 
 Qui sotto puoi trovare delle repo popolari dove cercare problemi semplici da cui partire. Continua nelle repo per imparare di più
 


### PR DESCRIPTION
## What this PR changes
- Replaces the outdated Slack invitation in `docs/translations/README.it.md`
- Adds the current `code-contributions` pointer

## Why
This translation still referenced Slack while the project has moved contributors toward the code-contributions path.

## Scope
- Single-file docs update
- No functional/code impact
