### PR TITLE
docs(ps): replace outdated Slack reference with code-contributions link

### DIFF
--- a/docs/translations/README.ps.md
+++ b/docs/translations/README.ps.md
@@ -131,7 +131,7 @@ fatal: Authentication failed for 'https://github.com/&lt;your-username&gt;/first
 تاسو په بریالیتوب سره د فورک، کلون، ایډیټ، او pull request مرحلې بشپړې کړې. تاسې له دې نه وروسته کولی شئ چې په خلاص-سرچېنه پروژو کې په همدې طریقه برخه واخلئ.
 
 - خپل لومړئ ګډون ولمانځئ او له خپلو ملګرو سره یې [شریک کړئ](https://firstcontributions.github.io/#social-share).
-- که کومه ستونزه یا پوښتنه لرئ، کولای شئ زموږ د Slack ټیم سره یوځای شئ.
+- که غواړئ لا ډېر تمرین وکړئ، د [code contributions](https://github.com/roshanjossey/code-contributions) زېرمه وګورئ.
 - اوس کولای شئ په نورو پروژو کې هم ګډون وکړئ. [دلته د پروژو لیست وګورئ](https://firstcontributions.github.io/#project-list).
 
 ## <a href="additional-material/git_workflow_scenarios/additional-material.md">اضافي مواد</a>


### PR DESCRIPTION
## What this PR changes
- Replaces the remaining Slack reference in `docs/translations/README.ps.md`
- Points readers to the active `code-contributions` repository instead

## Why
Issue #104790 requests removing Slack references from the Pashto translation as the project has moved away from Slack links.

Addresses #104790.
