### PR TITLE
Add Scott Boudreaux (Elyan Labs)

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -1,4 +1,5 @@
 # Contributors
+- [Scott Boudreaux (Elyan Labs)](https://github.com/Scottcjn)
 - [Avuram Chandra Mohan Reddy](https://github.com/chandramohan385)
 - [Prashant Kumar Tuhania](https://github.com/prashantkumar342)
 - [Mrrrrrrt](https://github.com/Mrrrrrrt)


### PR DESCRIPTION
Adding myself as a contributor. I maintain RustChain (Proof-of-Antiquity blockchain), ram-coffers (NUMA-aware LLM inference), and other open source projects at Elyan Labs.