### PR TITLE
update git checkout to git switch in French README

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -1197,6 +1197,7 @@ Rongxin Zhang
 - [sathvikkv](https://github.com/sathvikkv556)
 - [shreyanth-sureshkrishnaa](https://github.com/shreyanth-sureshkrishnaa)
 - [Mohit Kumar](https://github.com/mohitk23)
+- [lboeglin](https://github.com/lboeglin)
 - [shwetasharma](https://github.com/ShwetaSharmaDev)
 - [snopstor](https://github.com/snopstor)
 - [socks5-sniffer](https://github.com/socks5-sniffer)

--- a/docs/translations/README.fr.md
+++ b/docs/translations/README.fr.md
@@ -49,22 +49,24 @@ Déplacez-vous dans le répertoire du projet nouvellement cloné (si vous n'y ê
 cd first-contributions
 ```
 
-Maintenant créez une branche avec la commande `git checkout` :
+Maintenant créez une branche avec la commande `git switch` :
 
 ```bash
-git checkout -b <add-votre-nom>
+git switch -c <add-votre-nom>
 ```
 
 Par exemple :
 
 ```bash
-git checkout -b add-koffi-sani
+git switch -c add-koffi-sani
 ```
 
 (Le nom de la branche n'a pas besoin de contenir le terme _add_, mais il est mieux de l'inclure car l'objectif de cette branche est d'ajouter votre nom à une liste.)
 
-<details> <summary> <strong>Si vous rencontrez une erreur avec git switch, cliquez ici :</strong> </summary>
-Si le message "Git: switch is not a git command. See git –help" s’affiche, c’est probablement parce que vous utilisez une ancienne version de Git.
+<details> 
+<summary> <strong>Si vous rencontrez une erreur avec git switch, cliquez ici :</strong> </summary>
+
+Si le message "Git: `switch` is not a git command. See `git –help`" s’affiche, c’est probablement parce que vous utilisez une ancienne version de Git.
 
 Dans ce cas, essayez plutôt :
 


### PR DESCRIPTION

- [x] I had fun going through this tutorial (ノ^o^)ノ and learned on the way ٩(＾◡＾)۶
- [x] There are some things I'd like to improve in this tutorial. I have written them below.

The French README was using the outdated git checkout command to create and switch branches, while the English README has already been updated to use `git switch`. This PR aligns the French README with the English version.

While going through the French README, I noticed a few things that could be improved in a future PR:

The file is inconsistent with technical terms: "Fork" is used in some places and "embranchement" in others. Should technical terms like "Fork" be fully translated (e.g. "bifurcation") or kept in English for developer familiarity?
There are other differences between the French and English README that could be aligned in a follow-up PR.

Happy to work on these in separate PRs, or open issues so someone else can contribute if you are interested in these changes 