### PR TITLE
Add markdown validation for documentation

### DIFF
--- a/.github/workflows/markdown-validation.yml
+++ b/.github/workflows/markdown-validation.yml
@@ -1,0 +1,38 @@
+name: Markdown Validation
+
+on:
+  pull_request:
+    paths:
+      - "**/*.md"
+      - "scripts/markdown_validator.py"
+
+jobs:
+  validate-markdown:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Collect changed Markdown files
+        id: changed-files
+        run: |
+          files=$(git diff --name-only --diff-filter=ACMRT "${{ github.event.pull_request.base.sha }}" "${{ github.sha }}" -- '*.md')
+          {
+            echo 'files<<EOF'
+            echo "$files"
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Validate changed Markdown files
+        if: steps.changed-files.outputs.files != ''
+        run: |
+          mapfile -t files <<< "${{ steps.changed-files.outputs.files }}"
+          python3 scripts/markdown_validator.py --fail-on-warning "${files[@]}"

--- a/README.md
+++ b/README.md
@@ -203,11 +203,11 @@ replacing `your-branch-name` with the name of the branch you created earlier.
   Go to [GitHub's tutorial](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account) on generating and configuring an SSH key to your account.
 
   Also, you might want to run 'git remote -v' to check your remote address.
-  
+
   If it looks anything like this:
   <pre>origin	https://github.com/your-username/your_repo.git (fetch)
   origin	https://github.com/your-username/your_repo.git (push)</pre>
-  
+
   change it using this command:
   ```bash
   git remote set-url origin git@github.com:your-username/your_repo.git
@@ -238,6 +238,16 @@ If you'd like more practice, checkout [code contributions](https://github.com/ro
 Now let's get you started with contributing to other projects. We've compiled a list of projects with easy issues you can get started on. Check out [the list of projects in the web app](https://firstcontributions.github.io/#project-list).
 
 ### [Additional material](docs/additional-material/git_workflow_scenarios/additional-material.md)
+
+## Validate Markdown docs
+
+To check documentation formatting locally, run:
+
+```bash
+python3 scripts/markdown_validator.py --fail-on-warning
+```
+
+You can also pass specific files or folders to validate only the docs you changed.
 
 ## Tutorials Using Other Tools
 

--- a/docs/gui-tool-tutorials/sourcetree-macos-tutorial.md
+++ b/docs/gui-tool-tutorials/sourcetree-macos-tutorial.md
@@ -21,7 +21,7 @@ Please note, this tutorial is for MacOS. It is similar to Sourcetree on Windows 
 	*** This is commented out until      ***
 	*** a Windows tutorial can be created***
 	****************************************
-Please note, this tutorial is for MacOS. Please refer to the [Windows Tutorial]() for Sourcetree if that is what you want to use.
+Please note, this tutorial is for MacOS. A Sourcetree Windows tutorial is not available yet.
 -->
 
 Download [Sourcetree](https://www.sourcetreeapp.com), Install and open it.

--- a/scripts/markdown_validator.py
+++ b/scripts/markdown_validator.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Validate common Markdown formatting issues in this repository."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+
+DEFAULT_TARGETS = ("README.md", "docs", "examples")
+HEADING_RE = re.compile(r"^(#{1,6})[ \t]+")
+MARKDOWN_IMAGE_RE = re.compile(r"!\[(?P<alt>[^\]]*)\]\((?P<target>[^)]*)\)")
+MARKDOWN_LINK_RE = re.compile(r"(?<!!)\[(?P<text>[^\]]*)\]\((?P<target>[^)]*)\)")
+HTML_IMG_RE = re.compile(r"<img\b[^>]*>", re.IGNORECASE)
+HTML_ALT_RE = re.compile(r"""\balt\s*=\s*(['"])(?P<value>.*?)\1""", re.IGNORECASE)
+FENCE_RE = re.compile(r"^[ \t]*(```|~~~)")
+
+
+@dataclass(frozen=True)
+class Warning:
+    path: Path
+    line: int
+    check: str
+    message: str
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Validate Markdown files for skipped heading levels, trailing "
+            "whitespace, missing image alt text, and empty links."
+        )
+    )
+    parser.add_argument(
+        "targets",
+        nargs="*",
+        help=(
+            "Files or directories to scan. Defaults to README.md, docs/, and "
+            "examples/ when they exist."
+        ),
+    )
+    parser.add_argument(
+        "--fail-on-warning",
+        action="store_true",
+        help="Exit with status 1 when warnings are found.",
+    )
+    return parser.parse_args()
+
+
+def iter_markdown_files(targets: Iterable[str]) -> list[Path]:
+    resolved_targets = list(targets) if targets else list(DEFAULT_TARGETS)
+    files: set[Path] = set()
+
+    for raw_target in resolved_targets:
+        path = Path(raw_target)
+        if not path.exists():
+            continue
+        if path.is_file() and path.suffix.lower() == ".md":
+            files.add(path)
+            continue
+        if path.is_dir():
+            files.update(candidate for candidate in path.rglob("*.md") if candidate.is_file())
+
+    return sorted(files)
+
+
+def validate_file(path: Path) -> list[Warning]:
+    warnings: list[Warning] = []
+    in_fence = False
+    previous_heading_level: int | None = None
+
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except UnicodeDecodeError:
+        lines = path.read_text(encoding="utf-8", errors="ignore").splitlines()
+
+    for line_number, line in enumerate(lines, start=1):
+        if FENCE_RE.match(line):
+            in_fence = not in_fence
+            continue
+
+        if line.rstrip(" \t") != line:
+            warnings.append(
+                Warning(path, line_number, "trailing-whitespace", "Line has trailing whitespace.")
+            )
+
+        if in_fence:
+            continue
+
+        heading_match = HEADING_RE.match(line)
+        if heading_match:
+            level = len(heading_match.group(1))
+            if previous_heading_level is not None and previous_heading_level >= 2:
+                if level > previous_heading_level + 1:
+                    warnings.append(
+                        Warning(
+                            path,
+                            line_number,
+                            "heading-level",
+                            (
+                                "Heading level jumps from "
+                                f"H{previous_heading_level} to H{level}."
+                            ),
+                        )
+                    )
+            previous_heading_level = level
+
+        for match in MARKDOWN_IMAGE_RE.finditer(line):
+            if not match.group("alt").strip():
+                warnings.append(
+                    Warning(
+                        path,
+                        line_number,
+                        "image-alt",
+                        "Markdown image is missing alt text.",
+                    )
+                )
+
+        for html_image in HTML_IMG_RE.finditer(line):
+            alt_match = HTML_ALT_RE.search(html_image.group(0))
+            if alt_match is None or not alt_match.group("value").strip():
+                warnings.append(
+                    Warning(
+                        path,
+                        line_number,
+                        "image-alt",
+                        "HTML image is missing alt text.",
+                    )
+                )
+
+        for match in MARKDOWN_LINK_RE.finditer(line):
+            if not match.group("target").strip():
+                warnings.append(
+                    Warning(
+                        path,
+                        line_number,
+                        "empty-link",
+                        "Markdown link target is empty.",
+                    )
+                )
+
+    return warnings
+
+
+def main() -> int:
+    args = parse_args()
+    files = iter_markdown_files(args.targets)
+
+    if not files:
+        print("No Markdown files found.")
+        return 0
+
+    warnings = [warning for path in files for warning in validate_file(path)]
+
+    for warning in warnings:
+        print(f"{warning.path}:{warning.line}: {warning.check}: {warning.message}")
+
+    print(f"Scanned {len(files)} Markdown file(s). Found {len(warnings)} warning(s).")
+
+    if warnings and args.fail_on_warning:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Fixes #113128

This PR adds automated Markdown validation for documentation files in the repository.

## What Changed

- [x] Added `scripts/markdown_validator.py` to detect:
  - skipped heading levels
  - trailing whitespace
  - images without alt text
  - empty Markdown links
- [x] Added a GitHub Actions workflow to validate changed `.md` files on pull requests
- [x] Documented local usage in `README.md`
- [x] Fixed an existing empty link in `docs/gui-tool-tutorials/sourcetree-macos-tutorial.md`

## Validation

- [x] `python3 -m py_compile scripts/markdown_validator.py`
- [x] `python3 scripts/markdown_validator.py --fail-on-warning README.md`
- [x] `python3 scripts/markdown_validator.py --fail-on-warning docs/gui-tool-tutorials/sourcetree-macos-tutorial.md`

## Notes

The repository already has many pre-existing Markdown formatting warnings, so the workflow is scoped to changed Markdown files only.

- [x] I had fun going through this tutorial (ノ^o^)ノ and learned on the way ٩(＾◡＾)۶
- [ ] There are some things I'd like to improve in this tutorial. I have written them below.
- [ ] There were steps where I had errors while following this tutorial. I have written them below.