### PR TITLE
Add Markdown validator script for documentation formatting checks

### DIFF
--- a/.github/workflows/markdown-validator.yml
+++ b/.github/workflows/markdown-validator.yml
@@ -1,0 +1,23 @@
+name: Markdown Validator
+
+on:
+  push:
+    paths:
+      - "**.md"
+      - "docs/**"
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+
+      - name: Run Validator
+        run: python scripts/markdown_validator.py

--- a/scripts/markdown_validator.py
+++ b/scripts/markdown_validator.py
@@ -1,0 +1,44 @@
+import os
+import re
+
+def check_trailing_whitespace(line, line_num, file):
+    if line.rstrip('\n').endswith(' '):
+        print(f"[Trailing whitespace] {file}:{line_num}")
+
+def check_empty_links(line, line_num, file):
+    if re.search(r'\[\]\(\)', line):
+        print(f"[Empty link] {file}:{line_num}")
+
+def check_images_without_alt(line, line_num, file):
+    if re.search(r'!\[\]\(', line):
+        print(f"[Image missing alt text] {file}:{line_num}")
+
+def check_heading_levels(prev_level, line, line_num, file):
+    match = re.match(r'^(#+)', line)
+    if match:
+        level = len(match.group(1))
+        if prev_level and level > prev_level + 1:
+            print(f"[Skipped heading level] {file}:{line_num}")
+        return level
+    return prev_level
+
+def scan_file(filepath):
+    prev_heading = None
+
+    with open(filepath, "r", encoding="utf-8") as f:
+        for i, line in enumerate(f, 1):
+
+            check_trailing_whitespace(line, i, filepath)
+            check_empty_links(line, i, filepath)
+            check_images_without_alt(line, i, filepath)
+
+            prev_heading = check_heading_levels(prev_heading, line, i, filepath)
+
+def scan_markdown_files(root_dir):
+    for root, dirs, files in os.walk(root_dir):
+        for file in files:
+            if file.endswith(".md"):
+                scan_file(os.path.join(root, file))
+
+if __name__ == "__main__":
+    scan_markdown_files(".")

--- a/scripts/markdown_validator.py
+++ b/scripts/markdown_validator.py
@@ -1,24 +1,31 @@
 import os
 import re
+from datetime import datetime
+
+LOG_FILE = "markdown_validation_log.txt"
+
+def log(message):
+    with open(LOG_FILE, "a", encoding="utf-8") as f:
+        f.write(message + "\n")
 
 def check_trailing_whitespace(line, line_num, file):
     if line.rstrip('\n').endswith(' '):
-        print(f"[Trailing whitespace] {file}:{line_num}")
+        log(f"[Trailing whitespace] {file}:{line_num}")
 
 def check_empty_links(line, line_num, file):
     if re.search(r'\[\]\(\)', line):
-        print(f"[Empty link] {file}:{line_num}")
+        log(f"[Empty link] {file}:{line_num}")
 
 def check_images_without_alt(line, line_num, file):
     if re.search(r'!\[\]\(', line):
-        print(f"[Image missing alt text] {file}:{line_num}")
+        log(f"[Image missing alt text] {file}:{line_num}")
 
 def check_heading_levels(prev_level, line, line_num, file):
     match = re.match(r'^(#+)', line)
     if match:
         level = len(match.group(1))
         if prev_level and level > prev_level + 1:
-            print(f"[Skipped heading level] {file}:{line_num}")
+            log(f"[Skipped heading level] {file}:{line_num}")
         return level
     return prev_level
 
@@ -41,4 +48,5 @@ def scan_markdown_files(root_dir):
                 scan_file(os.path.join(root, file))
 
 if __name__ == "__main__":
+    log(f"\n--- Validation Run: {datetime.now()} ---")
     scan_markdown_files(".")


### PR DESCRIPTION
This PR introduces a simple Python script that scans Markdown files in the repository and reports common formatting issues such as:

- skipped heading levels
- trailing whitespace
- images without alt text
- empty links

scripts/
   markdown_validator.py

.github/
   workflows/
      markdown-validator.yml

The script scans all .md files and prints warnings to help contributors maintain documentation consistency.

The validator runs automatically via GitHub Actions whenever Markdown files are updated.

<img width="1321" height="874" alt="image" src="https://github.com/user-attachments/assets/20c2a389-135d-405b-bda6-e8f7092b07df" />
