### PR TITLE
Fixed #113086 broken hindi readme

### DIFF
--- a/docs/translations/README.hi.md
+++ b/docs/translations/README.hi.md
@@ -119,11 +119,30 @@ git push origin <अपनी-शाखा-का-नाम-जोड़ें>
 
 ## शिक्षण अन्य साधनो का उपयोग करने के लिए
 
-|<a href="../github-desktop-tutorial.md"><img alt="गिटहब डेस्कटॉप" src="https://desktop.github.com/images/desktop-icon.svg" width="100"></a> |
-<a href="../github-windows-vs2017-tutorial.md"><img alt="विज़ुअल स्टूडियो 2017" src="https://upload.wikimedia.org/wikipedia/commons/c/cd/Visual_Studio_2017_Logo.svg" width="100"></a> |
-<a href="../gitkraken-tutorial.md"><img alt="गिटक्रैकेन" src="https://firstcontributions.github.io/assets/gui-tool-tutorials/gitkraken-tutorial/gk-icon.png" width="100"></a> |
-<a href="../github-windows-vs-code-tutorial.md"><img alt="वीएस कोड" src="https://upload.wikimedia.org/wikipedia/commons/1/1c/Visual_Studio_Code_1.35_icon.png" width="100"></a> |
-<a href="sourcetree-macos-tutorial.md"><img alt="सॉर्सट्री ऐप" src="https://wac-cdn.atlassian.com/dam/jcr:81b15cde-be2e-4f4a-8af7-9436f4a1b431/Sourcetree-icon-blue.svg" width="100"></a>
-|
-| ------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [GitHub Desktop](../gui-tool-tutorials/github-desktop-tutorial.md)                                                                          | [Visual Studio 2017](../gui-tool-tutorials/github-windows-vs2017-tutorial.md)                                                                                                       | [GitKraken](../gui-tool-tutorials/gitkraken-tutorial.md)                                                                                                                     | [Visual Studio Code](../gui-tool-tutorials/github-windows-vs-code-tutorial.md)                                                                                               | [Atlassian Sourcetree](../gui-tool-tutorials/sourcetree-macos-tutorial.md)                                                                                                                |
+<p align="center">
+  <a href="../gui-tool-tutorials/github-desktop-tutorial.md">
+    <img src="https://desktop.github.com/images/desktop-icon.svg" width="100"/>
+  </a>
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+  <a href="../gui-tool-tutorials/github-windows-vs2017-tutorial.md">
+    <img src="https://upload.wikimedia.org/wikipedia/commons/c/cd/Visual_Studio_2017_Logo.svg" width="100"/>
+  </a>
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+  <a href="../gui-tool-tutorials/gitkraken-tutorial.md">
+    <img src="https://firstcontributions.github.io/assets/gui-tool-tutorials/gitkraken-tutorial/gk-icon.png" width="100"/>
+  </a>
+  &nbsp;&nbsp;&nbsp;&nbsp;
+  <a href="../gui-tool-tutorials/github-windows-vs-code-tutorial.md">
+    <img src="https://upload.wikimedia.org/wikipedia/commons/1/1c/Visual_Studio_Code_1.35_icon.png" width="100"/>
+  </a>
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+  <a href="../gui-tool-tutorials/github-windows-vs-code-tutorial.md">
+    <img src="https://wac-cdn.atlassian.com/dam/jcr:81b15cde-be2e-4f4a-8af7-9436f4a1b431/sourcetree-icon-blue.svg" width="100"/>
+  </a>
+</p>
+
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[GitHub Desktop](../gui-tool-tutorials/github-desktop-tutorial.md)&nbsp;&nbsp;
+[Visual Studio 2017](../gui-tool-tutorials/github-windows-vs2017-tutorial.md)
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[GitKraken](../gui-tool-tutorials/gitkraken-tutorial.md)
+&nbsp;&nbsp;&nbsp;[Visual Studio Code](../gui-tool-tutorials/github-windows-vs-code-tutorial.md)
+&nbsp;[Atlassian Sourcetree](../gui-tool-tutorials/sourcetree-macos-tutorial.md)

--- a/docs/translations/README.hi.md
+++ b/docs/translations/README.hi.md
@@ -119,7 +119,7 @@ git push origin <अपनी-शाखा-का-नाम-जोड़ें>
 
 ## शिक्षण अन्य साधनो का उपयोग करने के लिए
 
-<p align="center">
+<p>
   <a href="../gui-tool-tutorials/github-desktop-tutorial.md">
     <img src="https://desktop.github.com/images/desktop-icon.svg" width="100"/>
   </a>
@@ -141,7 +141,7 @@ git push origin <अपनी-शाखा-का-नाम-जोड़ें>
   </a>
 </p>
 
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[GitHub Desktop](../gui-tool-tutorials/github-desktop-tutorial.md)&nbsp;&nbsp;
+[GitHub Desktop](../gui-tool-tutorials/github-desktop-tutorial.md)&nbsp;&nbsp;
 [Visual Studio 2017](../gui-tool-tutorials/github-windows-vs2017-tutorial.md)
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[GitKraken](../gui-tool-tutorials/gitkraken-tutorial.md)
 &nbsp;&nbsp;&nbsp;[Visual Studio Code](../gui-tool-tutorials/github-windows-vs-code-tutorial.md)


### PR DESCRIPTION
fixes #113086
fixed the borken layout and git tool tutorial linking in  File: docs/translations/README.hi.md
before :
<img width="1568" height="578" alt="image" src="https://github.com/user-attachments/assets/2aad9bc2-c18b-4a32-b5f7-51c2bb12af6f" />
after:
<img width="1377" height="739" alt="Screenshot 2026-03-15 175136" src="https://github.com/user-attachments/assets/21cd537c-40ad-4b46-90a6-00644d246f43" />

