### PR TITLE
Add amd1.7 to Contributors list

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -1843,3 +1843,4 @@ Merjen Amanmuradova
 - [Paawan Garg](https://github.com/Paawangarg1084)
 - [Swati Chaudhari](https://github.com/ChaudhariSwati)
 - [Ishita Singh](https://github.com/codeishitech)
+- ### [amd1.7](https://github.com/amd1-7)


### PR DESCRIPTION
I have added my profile to the `Contributors.md` file as part of my first open-source contribution. 

- **Username:** amd1-7
- **Project:** First Contributions