### PR TITLE
Fix: Replace outdated link in Galician README

### DIFF
--- a/docs/translations/README.gl.md
+++ b/docs/translations/README.gl.md
@@ -108,4 +108,4 @@ Axiña mesturarei os teus cambios (facendo *merge*) na master branch deste proxe
 
 ## Onde ir dende aquí?
 
-Se queres practicar máis e contribuír a código aberto, mira [Code Contributions](https://github.com/roshanjossey/code-contributions).
+Se queres practicar máis e contribuír a código aberto, mira [Code Contributions](https://github.com/firstcontributions/first-contributions).


### PR DESCRIPTION
Addresses #104253

### Changes made
- Replaced outdated Code Contributions link in the Galician README
- Removed reference to old/incorrect repository
- Updated link to match the official repository used in the English README

### Why this change
- Ensures consistency across translations
- Prevents users from being redirected to an outdated repository
- Improves overall documentation accuracy

### Files modified
- docs/translations/README.gl.md