### PR TITLE
fix: replace Slack link with code contributions repo in Turkmen README

### DIFF
--- a/docs/translations/README.tm.md
+++ b/docs/translations/README.tm.md
@@ -130,7 +130,7 @@ Gutlaýas! Siz standart goşant goşujy hökmünde kän gabat gelinýän _forkla
 
 Eden goşandyňyza begeniň we dostlaryňyz bilen paýlaşyň!
 
-[Bu baglanma](https://firstcontributions.github.io/#social-share) arkaly hem birnäçe gyzykly proýektlere öz goşandyňyzy goşup bilýäňiz.
+[Code contributions repository](https://github.com/firstcontributions/first-contributions) arkaly hem birnäçe gyzykly proýektlere öz goşandyňyzy goşup bilýäňiz.
 
 
 


### PR DESCRIPTION
Addresses #104821

Replaced the Slack link with the code contributions repository link in the Turkmen README under the "Where to go from here" section.