### PR TITLE
docs(tr): update git commands to modern usage in Turkish README

### DIFF
--- a/docs/translations/README.tr.md
+++ b/docs/translations/README.tr.md
@@ -1,3 +1,4 @@
+
 [![Open Source Love](https://badges.frapsoft.com/os/v1/open-source.svg?v=103)](https://github.com/ellerbrock/open-source-badges/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 [![Open Source Helpers](https://www.codetriage.com/roshanjossey/first-contributions/badges/users.svg)](https://www.codetriage.com/roshanjossey/first-contributions)
@@ -45,17 +46,22 @@ Eğer henüz klasör içerisinde değilseniz komut isteminde ana klasörünün k
 ```bash
 cd first-contributions
 ```
-`git checkout` komutunu kullanarak yeni bir dal(branch) oluşturun:
+Yeni bir dal (branch) oluşturmak için aşağıdaki komutu kullanın:
 ```bash
-git checkout -b <sizin-yeni-dal-isminiz>
+git switch -c <sizin-yeni-dal-isminiz>
 ```
 
 Örneğin:
 ```bash
-git checkout -b ekle-aydin-cagri-dumlu
+git switch -c ekle-aydin-cagri-dumlu
 ```
 (Dal ismi içinde *ekle* kelimesinin geçme zorunluluğu yok, fakat bu dal isminizi katkı sunanlar listesine ekleme amacıyla oluşturulduğundan, ekle yazmak mantıklı olacaktır.)
 
+Eğer `git switch` komutu hata verirse Git sürümünüz eski olabilir. Bu durumda aşağıdaki komutu kullanabilirsiniz:
+
+```bash
+git checkout -b <sizin-yeni-dal-isminiz>
+```
 ## Gerekli değişiklikleri yapma ve değişiklikleri onaylama
 
 Şimdi, bir metin editöründe `Contributors.md` dosyasını açın. Basit bir işaretleme dili olan Markdown'a alışkın olmanız gerekmektedir. Nasıl kullanacağınızı öğrenmek için bu [kopya kağıdına](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet) göz atabilirsiniz.
@@ -96,7 +102,7 @@ git commit -m "<isminiz> katkıda bulunanlar listesine eklendi"
 
 `git push` komutu ile değişikliklerinizi ittirin:
 ```bash
-git push origin <ekle-sizin-dal-isminiz>
+git push -u origin <ekle-sizin-dal-isminiz>
 ```
 `<ekle-sizin-dal-isminiz>` yerine daha önce oluşturduğunuz dalın ismini girin.
 


### PR DESCRIPTION
This PR updates the Git commands used in the Turkish README to reflect modern Git usage and improve the beginner workflow.

Changes:
- Replace `git checkout -b` with `git switch -c`
- Add a fallback note for older Git versions using `git checkout -b`
- Update push command to `git push -u origin` so the upstream branch is set automatically

These updates make the Turkish documentation consistent with modern Git practices and closer to the workflow described in the English README.

Before submitting this pull request, check the changes to see it's only the changes you made intentionally
If there are changes to other lines you didn't make deliberately, it's possible that your IDE made the changes with a utility like prettier.
Next time, make sure that you only add your changes by using `git add -p` and rather than `git add Contributors.md`

If you're doing something in the checklist below, put an `x` inside `[ ]` so that `- [ ]` becomes `- [x]`

- [ ] I had fun going through this tutorial (ノ^o^)ノ and learned on the way ٩(＾◡＾)۶
- [ ] There are some things I'd like to improve in this tutorial. I have written them below.
- [ ] There were steps where I had errors while following this tutorial. I have written them below.