### PR TITLE
ci: fix auto-merge skip bug on multiple line Contributors.md changes

### DIFF
--- a/.github/workflows/auto-pr-merge.yml
+++ b/.github/workflows/auto-pr-merge.yml
@@ -176,6 +176,19 @@ jobs:
               // Set GitHub Action as failed
               core.setFailed(error.message);
             }
+      # Post a comment if Contributors.md has multiple line changes
+      - name: Post comment if Contributors.md has too many changes
+        if: env.only_contributors == 'true' && env.one_line_change == 'false'
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: "Thank you for your pull request! \n\nThis PR modifies Contributors.md with multiple changes. A maintainer will review it soon!\n\nThank you for your contribution! "
+            })
 
       # Post a comment on the pull request if it was not merged automatically
       - name: Post comment on PR if not merged automatically


### PR DESCRIPTION
This PR fixes a logic gap in the auto_merge_prs.yml workflow where contributors are left without bot feedback if their PR has multiple line changes in Contributors.md.

The Bug: Previously, if a PR only modified Contributors.md (only_contributors == 'true') but changed more than 1-2 lines (one_line_change == 'false'), both the auto-merge step and the review-fallback comment step were being skipped, leaving contributors in the dark.

The Fix: Added a specific action step to trigger when env.only_contributors == 'true' and env.one_line_change == 'false'. The workflow bot will now properly comment that a maintainer review is required instead of failing silently.

Addresses #111414