### PR TITLE
docs: replace stale "master" branch references with "main"

### DIFF
--- a/docs/additional-material/git_workflow_scenarios/moving-a-commit-to-a-different-branch.md
+++ b/docs/additional-material/git_workflow_scenarios/moving-a-commit-to-a-different-branch.md
@@ -19,7 +19,7 @@ Now your changes are on the correct branch
 ### Moving the latest commits to a new Branch
 To do this, type:  
 ```git branch newbranch``` -  Creates a new Branch. Saving all the Commits.  
-```git reset --hard HEAD~#``` - Move master back by # commits. Remember, these commits will be gone from master  
+```git reset --hard HEAD~#``` - Move the current branch back by # commits. Remember, these commits will be gone from it  
 ```git checkout newbranch``` - Goes to the branch you created. It will have all the commits.  
 
 Remember: Any changes not committed will be LOST.

--- a/docs/additional-material/git_workflow_scenarios/removing-a-file.md
+++ b/docs/additional-material/git_workflow_scenarios/removing-a-file.md
@@ -10,7 +10,7 @@ Git will no longer keep track of changes in the removed file. As far as Git know
 
 Notice that in the example above, the flag `--cached` is used. If we didn't add this flag, Git will remove the file from not just the repo, but from your file system too.
 
-If you commit the change with `git commit -m "Remove file1.js"` and pushed it to the remote repository using `git push origin master`, the remote repository will remove the file.
+If you commit the change with `git commit -m "Remove file1.js"` and push it to the remote repository using `git push origin main` (or whichever branch you're working on), the remote repository will remove the file.
 
 ## Additional features
 

--- a/docs/additional-material/git_workflow_scenarios/removing-branch-from-your-repository.md
+++ b/docs/additional-material/git_workflow_scenarios/removing-branch-from-your-repository.md
@@ -2,14 +2,14 @@
 
 If you have followed the tutorial up-to-now, our `<add-your-name>` branch has finished its purpose, it is time to delete it from your local machine's repo. This isn't necessary, but the name of this branch shows its rather special purpose. Its life can be made correspondingly short.
 
-First, let's merge your `<add-your-name>` to your master, so to go to your master branch:
+First, let's merge your `<add-your-name>` to your main, so to go to your main branch:
 ```
-git checkout master
+git checkout main
 ```
 
-Merge `<add-your-name>` to master:
+Merge `<add-your-name>` to main:
 ```
-git merge <add-your-name> master
+git merge <add-your-name> main
 ```
 
 Remove `<add-your-name>` on your local machine's repo:
@@ -26,6 +26,6 @@ git push origin --delete <add-your-name>
 ```
 
 Now, you know how to tidy your branches.
-With time, many commits will be added to my public repo. And the master branches of your local machine and of your GitHub fork won't be up-to-date. So in order to keep your repositories synchronized with mine, follow the steps below.
+With time, many commits will be added to my public repo. And the main branches of your local machine and of your GitHub fork won't be up-to-date. So in order to keep your repositories synchronized with mine, follow the steps below.
 
 #### [Keeping your fork synced with the repository](keeping-your-fork-synced-with-this-repository.md)

--- a/docs/gui-tool-tutorials/github-desktop-old-version-tutorial.md
+++ b/docs/gui-tool-tutorials/github-desktop-old-version-tutorial.md
@@ -89,7 +89,7 @@ Now submit the pull request.
 
 <img style="float: right;" src="https://firstcontributions.github.io/assets/gui-tool-tutorials/github-desktop-old-version-tutorial/submit-pull-request.png" alt="submit pull request" />
 
-Soon I'll be merging all your changes into the master branch of this project. You will get a notification email once the changes have been merged.
+Soon I'll be merging all your changes into the main branch of this project. You will get a notification email once the changes have been merged.
 
 ## Where to go from here?
 

--- a/docs/gui-tool-tutorials/github-desktop-tutorial.md
+++ b/docs/gui-tool-tutorials/github-desktop-tutorial.md
@@ -104,7 +104,7 @@ Now submit the pull request.
 
 <img src="https://firstcontributions.github.io/assets/gui-tool-tutorials/github-desktop-tutorial/submit-pull-request.png" alt="submit pull request" />
 
-Soon I'll be merging all your changes into the master branch of this project. You will get a notification email once the changes have been merged.
+Soon I'll be merging all your changes into the main branch of this project. You will get a notification email once the changes have been merged.
 
 ## Where to go from here?
 

--- a/docs/gui-tool-tutorials/github-windows-intellij-tutorial.md
+++ b/docs/gui-tool-tutorials/github-windows-intellij-tutorial.md
@@ -94,7 +94,7 @@ Now submit the pull request.
 
 <img src="https://firstcontributions.github.io/assets/gui-tool-tutorials/github-desktop-tutorial/submit-pull-request.png" alt="submit pull request" />
 
-Soon I'll be merging all your changes into the master branch of this project. You will get a notification email once the changes have been merged.
+Soon I'll be merging all your changes into the main branch of this project. You will get a notification email once the changes have been merged.
 
 ## Where to go from here?
 

--- a/docs/gui-tool-tutorials/github-windows-vs-code-tutorial.md
+++ b/docs/gui-tool-tutorials/github-windows-vs-code-tutorial.md
@@ -100,7 +100,7 @@ Now submit the pull request.
 
 <img src="https://firstcontributions.github.io/assets/Readme/submit-pull-request.png" alt="submit pull request" />
 
-Soon I'll be merging all your changes into the master branch of this project. You will get a notification email once the changes have been merged.
+Soon I'll be merging all your changes into the main branch of this project. You will get a notification email once the changes have been merged.
 
 ## Where to go from here?
 

--- a/docs/gui-tool-tutorials/github-windows-vs2017-tutorial.md
+++ b/docs/gui-tool-tutorials/github-windows-vs2017-tutorial.md
@@ -53,7 +53,7 @@ Click back to the Team Explorer tab and use the main navigation dropdown to open
 
 <img src="https://firstcontributions.github.io/assets/gui-tool-tutorials/github-windows-vs2017-tutorial/vs2017-04-branch1.png" alt="Branches view" />
 
-You should see the **first-contributions** repo and the default branch, which is called `master`.  Right-click on `master` and choose `New Local Branch From...`.
+You should see the **first-contributions** repo and the default branch, which is called `main`.  Right-click on `main` and choose `New Local Branch From...`.
 
 <img src="https://firstcontributions.github.io/assets/gui-tool-tutorials/github-windows-vs2017-tutorial/vs2017-05-branch2.png" alt="New branch" />
 
@@ -106,7 +106,7 @@ The first time you Push to GitHub, Visual Studio will ask for your GitHub creden
 
 After the Push operation completes, open your repo in GitHub and you should see a message indicating a recently pushed branch.
 
-You can view your changes by opening the `Branch: master` dropdown and selecting your new branch. Congratulations, you can share the branch URL with the world to show your progress!
+You can view your changes by opening the `Branch: main` dropdown and selecting your new branch. Congratulations, you can share the branch URL with the world to show your progress!
 
 <img src="https://firstcontributions.github.io/assets/gui-tool-tutorials/github-windows-vs2017-tutorial/vs2017-14-commit6.png" alt="View pushed branch on GitHub" />
 
@@ -122,7 +122,7 @@ Now submit the pull request.
 
 <img src="https://firstcontributions.github.io/assets/gui-tool-tutorials/github-windows-vs2017-tutorial/submit-pull-request.png" alt="submit pull request" />
 
-Soon I'll be merging all your changes into the master branch of this project. You will get a notification email once the changes have been merged.
+Soon I'll be merging all your changes into the main branch of this project. You will get a notification email once the changes have been merged.
 
 ## Where to go from here?
 

--- a/docs/gui-tool-tutorials/gitkraken-tutorial.md
+++ b/docs/gui-tool-tutorials/gitkraken-tutorial.md
@@ -91,7 +91,7 @@ Click the Push button on the toolbar.
 
 <img style="float: right;" src="https://firstcontributions.github.io/assets/gui-tool-tutorials/gitkraken-tutorial/gk-origin.png" alt="origin or branch" />
 
-Submit changes on the origin branch if you want the changes to reflect in the master branch directly, else select the appropriate branch you want to push.
+Submit changes on the origin branch if you want the changes to reflect in the main branch directly, else select the appropriate branch you want to push.
 
 
 ## Submit your changes for review
@@ -104,7 +104,7 @@ Now submit the pull request.
 
 <img style="float: right;" src="https://firstcontributions.github.io/assets/gui-tool-tutorials/gitkraken-tutorial/submit-pull-request.png" alt="submit pull request" />
 
-Soon I'll be merging all your changes into the master branch of this project. You will get a notification email once the changes have been merged.
+Soon I'll be merging all your changes into the main branch of this project. You will get a notification email once the changes have been merged.
 
 ## Where to go from here?
 

--- a/docs/gui-tool-tutorials/sourcetree-macos-tutorial.md
+++ b/docs/gui-tool-tutorials/sourcetree-macos-tutorial.md
@@ -120,7 +120,7 @@ Now submit the pull request.
 
 <img style="float: right;" src="https://firstcontributions.github.io/assets/gui-tool-tutorials/sourcetree-macos-tutorial/submit-pull-request.png" alt="submit pull request" />
 
-Soon I'll be merging all your changes into the master branch of this project. You will get a notification email once the changes have been merged.
+Soon I'll be merging all your changes into the main branch of this project. You will get a notification email once the changes have been merged.
 
 ## Where to go from here?
 

--- a/docs/gui-tool-tutorials/sublime-merge-tutorial.md
+++ b/docs/gui-tool-tutorials/sublime-merge-tutorial.md
@@ -89,7 +89,7 @@ or hit the small arrow in upward direction in the right hand corner.
 
 Login to your Github Account with your username and password
 
-Submit changes on the origin branch if you want the changes to reflect in the master branch directly, else select the appropriate branch you want to push.
+Submit changes on the origin branch if you want the changes to reflect in the main branch directly, else select the appropriate branch you want to push.
 
 
 ## Submit your changes for review
@@ -102,7 +102,7 @@ Now submit the pull request.
 
 <img style="float: right;" src="https://firstcontributions.github.io/assets/gui-tool-tutorials/sublime-merge-tutorial/submit-pull-request.png" alt="submit pull request" />
 
-Soon I'll be merging all your changes into the master branch of this project. You will get a notification email once the changes have been merged.
+Soon I'll be merging all your changes into the main branch of this project. You will get a notification email once the changes have been merged.
 
 ## Where to go from here?
 


### PR DESCRIPTION
## Summary

This repository's default branch is `main` (recent commit history confirms it — every auto-merged contributor PR lands on `main`), but 11 English-language tutorials still tell readers:
- that the default branch of this repo is called `master`, or
- that their PR will be merged into the `master` branch of this project.

Both claims are factually wrong today and confuse first-time contributors who check their fork against GitHub's current UI (GitHub's default is `main` for newly-created repos since 2020).

## Files updated

**GUI tool tutorials** (English only):
- `gui-tool-tutorials/github-desktop-tutorial.md`
- `gui-tool-tutorials/github-desktop-old-version-tutorial.md`
- `gui-tool-tutorials/gitkraken-tutorial.md`
- `gui-tool-tutorials/sublime-merge-tutorial.md`
- `gui-tool-tutorials/sourcetree-macos-tutorial.md`
- `gui-tool-tutorials/github-windows-intellij-tutorial.md`
- `gui-tool-tutorials/github-windows-vs-code-tutorial.md`
- `gui-tool-tutorials/github-windows-vs2017-tutorial.md` — also updated a screenshot caption referring to the `Branch: master` dropdown, which no longer matches GitHub's UI.

**Git workflow scenarios:**
- `additional-material/git_workflow_scenarios/removing-branch-from-your-repository.md`
- `additional-material/git_workflow_scenarios/moving-a-commit-to-a-different-branch.md` — comment said `\"move master back\"`; the scenario is branch-agnostic, now just refers to \"the current branch\".
- `additional-material/git_workflow_scenarios/removing-a-file.md` — example used `git push origin master`; now uses `git push origin main` with a note to substitute your branch.

## Intentionally left alone

- **`gitflow.md`** — keeps its `master`/`develop` terminology because the [Git Flow model](https://nvie.com/posts/a-successful-git-branching-model/) canonically uses those names. Changing it would describe a workflow that doesn't exist.
- **Translations** under `docs/translations/` and `docs/gui-tool-tutorials/translations/` — per `.github/CONTRIBUTING.md`, translation updates should go through the language reviewers listed in the contributing guide. I've flagged the affected files (Persian, Portuguese, Thai, Tamil, Spanish, Vietnamese, Greek, Hindi) so those can be picked up separately.

## Test plan

- [x] `git grep 'master branch of this project'` in English files → empty after this change.
- [x] Every touched line verified — no change alters meaning beyond swapping the branch name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)