### PR TITLE
docs: add cherry-picking guide to git workflow scenarios

### DIFF
--- a/docs/additional-material/git_workflow_scenarios/additional-material.md
+++ b/docs/additional-material/git_workflow_scenarios/additional-material.md
@@ -6,6 +6,10 @@ We assume that you have already finished with the basic tutorial before coming h
 This document provides information about how to amend a commit on the remote repository. Amending a commit is a way to modify the most recent commit you have made in your current branch. This can be helpful if you need to edit the commit message or if you forgot to include changes in the commit. You can continue to amend a commit until you push it to the remote repository.
 > Use this when you need to adjust a commit you made.
 
+### [Cherry-picking a commit](cherry-picking.md)
+This document explains how to use `git cherry-pick` to copy a single commit (or a range of commits) from one branch to another without merging the rest of the branch, and how to resolve conflicts that arise.
+> Use this when you need one specific commit on your branch — e.g. a hotfix — without bringing along everything else.
+
 ### [Configuring git](configuring-git.md)
 This document provides information about how to configure user details and other options in git.
 > Use this to better control your git configurations.

--- a/docs/additional-material/git_workflow_scenarios/cherry-picking.md
+++ b/docs/additional-material/git_workflow_scenarios/cherry-picking.md
@@ -1,0 +1,75 @@
+# Cherry-picking a commit
+
+What if there is one specific commit on another branch — a bug fix, a small feature, a config tweak — that you want on your branch, *without* merging everything else? That's what `git cherry-pick` is for. It takes the changes introduced by an existing commit and reapplies them as a new commit on your current branch.
+
+## When to cherry-pick (and when not to)
+
+Cherry-pick when:
+- You need a hotfix from `main` on a release branch, but don't want the rest of `main`.
+- A useful commit lives on a branch that isn't ready to merge.
+- You accidentally committed to the wrong branch and want to move just one commit.
+
+Avoid cherry-picking when:
+- You want *all* the changes from another branch — use `git merge` or `git rebase` instead.
+- The commit has already been merged into your branch — cherry-picking it again will create a duplicate commit with the same changes.
+
+## How to cherry-pick
+
+First, find the commit you want. `git log --oneline` is the easiest way — the short hash on the left is what you'll need:
+
+```
+git log --oneline <branch-name>
+```
+
+You should see something like:
+
+```
+a1b2c3d Fix off-by-one in pagination
+d4e5f6a Add caching to user lookup
+9a8b7c6 Update README
+```
+
+Switch to the branch where you want the commit to land:
+
+```
+git switch <your-branch>
+```
+
+Then cherry-pick the commit by its hash:
+
+```
+git cherry-pick a1b2c3d
+```
+
+Git will reapply the changes and create a new commit on your branch. The new commit has a different hash from the original — that's expected. The commit message is reused.
+
+## Cherry-picking a range of commits
+
+To pick several consecutive commits, pass a range. The `^` on the left-hand side makes it inclusive:
+
+```
+git cherry-pick a1b2c3d^..d4e5f6a
+```
+
+This picks every commit from `a1b2c3d` through `d4e5f6a`, in order.
+
+## Resolving conflicts during a cherry-pick
+
+If the commit touches lines that have also been changed on your branch, Git will pause and ask you to resolve the conflict — the same process as a merge conflict. Open the conflicted files, pick the right version of each conflicted section, then stage your fixes and continue:
+
+```
+git add <resolved-files>
+git cherry-pick --continue
+```
+
+If you'd rather bail out entirely and leave your branch as it was:
+
+```
+git cherry-pick --abort
+```
+
+For help resolving the conflicts themselves, see [Resolving Merge Conflicts](resolving-merge-conflicts.md).
+
+## A note on duplicate history
+
+Cherry-picking creates a *new* commit with the same changes, not a pointer to the original. That means the same change can appear on two branches with two different hashes. That's fine for a hotfix, but if you later merge one branch into the other, Git usually handles the duplicate gracefully (it sees no new changes to apply). If you see odd duplicate commits in your history, it's often because the same change was cherry-picked *and* later merged.


### PR DESCRIPTION
## Summary

Adds a beginner-friendly guide for `git cherry-pick`, matching the style of the existing scenario guides (e.g. `squashing-commits.md`, `resolving-merge-conflicts.md`).

Cherry-picking is one of the operations new contributors most commonly encounter once they're past their very first PR — a maintainer asks them to pull a hotfix onto a release branch, or they've accidentally committed to the wrong branch and need to move one commit. The repo already has scenario guides for adjacent operations (squashing, reverting, merging, resolving conflicts) but nothing on cherry-pick.

## Note on contribution workflow

`.github/CONTRIBUTING.md` says: *\"If you'd like to suggest a change in the tutorials or the workflow, please raise an issue. We can have a discussion to better understand the problem, get more people involved and make a collective decision.\"*

I'm happy to **close this PR and open an issue first** if that's the maintainers' preferred flow for new content — just say the word. I wrote this directly as a PR because having something concrete to review usually makes the \"is this worth having?\" conversation faster, but I don't want to skip a process you have for good reasons.

## What the guide covers

- **When cherry-pick is the right tool** (hotfix onto release branch, moving a commit off the wrong branch) and when it isn't (a full merge would be simpler; the commit is already in your history).
- Finding a commit's short hash with `git log --oneline`.
- Cherry-picking a single commit and a range (`a^..b` inclusive-range syntax).
- Resolving conflicts during a cherry-pick — `--continue` / `--abort`, with a cross-link to `resolving-merge-conflicts.md`.
- A short note on the duplicate-history surprise that can happen if the source branch is later merged in too.

Index entry added to `additional-material.md` under `Cherry-picking a commit`.

## Test plan

- [x] New file renders correctly in GitHub's markdown preview.
- [x] Internal link to `resolving-merge-conflicts.md` resolves.
- [x] Commands verified locally against a test repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)