### PR TITLE
docs: add signing-commits guide to git workflow scenarios

### DIFF
--- a/docs/additional-material/git_workflow_scenarios/additional-material.md
+++ b/docs/additional-material/git_workflow_scenarios/additional-material.md
@@ -34,6 +34,10 @@ This document provides information about how to resolve merge conflicts.
 This document provides information about how to revert a commit on the remote repository. It will come in handy in case you need to undo a commit that has already been pushed to Github.
 > Take these steps if you want to reverse a commit.
 
+### [Signing your commits](signing-commits.md)
+This document walks through signing commits with SSH (the simpler, modern path) or GPG so they show up with the green Verified badge on GitHub.
+> Use this when a project requires signed commits, or when you want to prove a commit really came from you.
+
 ### [Squashing Commits](squashing-commits.md)
 This document provides information about how to squash commits with an interactive rebase.
 > Use this if you want to open a PR in an open source project and the reviewer asks you to squash every commit into one, with an informative commit message.

--- a/docs/additional-material/git_workflow_scenarios/signing-commits.md
+++ b/docs/additional-material/git_workflow_scenarios/signing-commits.md
@@ -1,0 +1,87 @@
+# Signing your commits
+
+When you commit, Git records *your name and email* — but nothing stops someone else from configuring Git with your name and your email and pushing a commit that appears to be from you. Signing a commit proves that *you* (or at least, someone with access to your signing key) authored it. On GitHub, signed commits that Git recognises and verifies show up with a green **Verified** badge next to the commit.
+
+There are two common ways to sign commits: **SSH** and **GPG**. SSH signing is newer (Git 2.34+), simpler, and lets you reuse the SSH key you already use to push to GitHub. Most first-time signers should start there.
+
+## Signing with SSH (recommended for beginners)
+
+If you already push to GitHub over SSH, you already have an SSH key at `~/.ssh/id_ed25519.pub` (or similar). Tell Git to use that key for signing:
+
+```
+git config --global gpg.format ssh
+git config --global user.signingkey ~/.ssh/id_ed25519.pub
+```
+
+Then turn on signing by default:
+
+```
+git config --global commit.gpgsign true
+```
+
+From now on, `git commit` will sign every commit with that SSH key.
+
+Finally, upload the same public key to GitHub **as a signing key** so it can verify your signatures. On GitHub, go to **Settings → SSH and GPG keys → New SSH key**, paste the contents of the `.pub` file, and set the **Key type** to *Signing Key*. (The same key can be registered twice — once as an Authentication key to push, once as a Signing key to verify commits.)
+
+Make a test commit and push it. The commit page on GitHub should show a green **Verified** badge.
+
+## Signing with GPG
+
+If your project or employer requires GPG, the steps are similar but you'll need a GPG key first.
+
+Generate a key:
+
+```
+gpg --full-generate-key
+```
+
+Accept the defaults (RSA, 4096 bits) and use the email address you use on GitHub. When it's done, find your key ID:
+
+```
+gpg --list-secret-keys --keyid-format=long
+```
+
+The output has a line like `sec   rsa4096/ABCD1234EFGH5678 ...`. The part after the slash (`ABCD1234EFGH5678`) is your key ID.
+
+Configure Git to use it:
+
+```
+git config --global user.signingkey ABCD1234EFGH5678
+git config --global commit.gpgsign true
+```
+
+Export your public key and add it to GitHub under **Settings → SSH and GPG keys → New GPG key**:
+
+```
+gpg --armor --export ABCD1234EFGH5678
+```
+
+Copy the output (including the `-----BEGIN PGP PUBLIC KEY BLOCK-----` and `-----END PGP PUBLIC KEY BLOCK-----` lines) into the GitHub form.
+
+## Signing a single commit manually
+
+If you don't want to sign *every* commit, skip the `commit.gpgsign true` step and pass `-S` when you want a specific commit signed:
+
+```
+git commit -S -m "Fix off-by-one in pagination"
+```
+
+## Checking that signing works
+
+After committing, run:
+
+```
+git log --show-signature -1
+```
+
+You should see a line confirming the signature was made with your key. If you see `gpg: signing failed: Inappropriate ioctl for device` or a pin-entry error, export `GPG_TTY` in your shell:
+
+```
+export GPG_TTY=$(tty)
+```
+
+Add that line to your shell config (e.g. `~/.zshrc` or `~/.bashrc`) so it persists.
+
+## A note on commit email
+
+For GitHub's Verified badge to appear, the email on the commit must match an email you've added (and verified) on your GitHub account. If you're using GitHub's private "no-reply" email, make sure that's the one in `git config user.email`.


### PR DESCRIPTION
## Summary

Adds a beginner-friendly guide for signing commits, matching the style of the existing scenario guides.

Signing commits matters because Git's `user.name` / `user.email` are self-reported — nothing stops someone else from configuring Git with someone else's identity and pushing under that name. GitHub shows a green **Verified** badge next to commits it can cryptographically verify, and many projects (especially ones with release pipelines or security boundaries) now require signed commits. The repo's existing guides don't cover this.

## Note on contribution workflow

`.github/CONTRIBUTING.md` says: *\"If you'd like to suggest a change in the tutorials or the workflow, please raise an issue. We can have a discussion to better understand the problem, get more people involved and make a collective decision.\"*

Happy to **close this PR and open an issue first** if that's the maintainers' preferred flow for new content.

## What the guide covers

The guide leads with **SSH signing** (recommended for beginners) because:
- It's simpler than GPG — no keygen step, no pin-entry, no `gpg-agent` gotchas.
- It reuses the SSH key most contributors already have set up for pushing to GitHub.
- It's supported in Git 2.34+ (Nov 2021), which covers essentially every modern install.

**GPG is covered as the secondary path** for projects/employers that require it, including the classic `GPG_TTY` fix for pin-entry failing in a terminal.

Also covered:
- Per-commit `-S` flag for when you don't want to sign everything.
- `git log --show-signature -1` for verification.
- The commit-email gotcha — the signing email must match an email you've added (and verified) on your GitHub account, or the Verified badge doesn't appear.

## Test plan

- [x] New file renders correctly in GitHub's markdown preview.
- [x] All commands verified locally against a GitHub account.
- [x] No internal links added that could break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)