### PR TITLE
docs: add common-mistakes-and-how-to-fix-them guide

### DIFF
--- a/docs/additional-material/git_workflow_scenarios/additional-material.md
+++ b/docs/additional-material/git_workflow_scenarios/additional-material.md
@@ -6,6 +6,10 @@ We assume that you have already finished with the basic tutorial before coming h
 This document provides information about how to amend a commit on the remote repository. Amending a commit is a way to modify the most recent commit you have made in your current branch. This can be helpful if you need to edit the commit message or if you forgot to include changes in the commit. You can continue to amend a commit until you push it to the remote repository.
 > Use this when you need to adjust a commit you made.
 
+### [Common mistakes and how to fix them](common-mistakes-and-how-to-fix-them.md)
+A short FAQ for the things that go wrong most often for first-time contributors — wrong-branch commits, typo'd commit messages, PRs with merge conflicts, accidentally-committed secrets, rejected pushes, and how to recover from `git reset --hard` with the reflog.
+> Start here when something has gone wrong and you want the quickest safe fix.
+
 ### [Configuring git](configuring-git.md)
 This document provides information about how to configure user details and other options in git.
 > Use this to better control your git configurations.

--- a/docs/additional-material/git_workflow_scenarios/common-mistakes-and-how-to-fix-them.md
+++ b/docs/additional-material/git_workflow_scenarios/common-mistakes-and-how-to-fix-them.md
@@ -1,0 +1,125 @@
+# Common mistakes and how to fix them
+
+Everyone makes these mistakes their first few times — the Git commands are correct, the outcome is not what you wanted. This guide is a FAQ of the things that go wrong most often for new contributors and the shortest safe fix for each.
+
+If a situation below links to a deeper guide, follow that — the short version here is meant to get you unstuck, the linked guide explains *why*.
+
+## "I committed to the wrong branch"
+
+You made a commit on `main` (or some other branch) when you meant to commit it on your feature branch.
+
+If you haven't pushed yet, you can move the commit:
+
+```
+git branch feature-branch          # create the branch here, at HEAD
+git reset --hard HEAD~1            # rewind the current branch by one commit
+git switch feature-branch          # the commit is waiting here
+```
+
+For more detail and the multi-commit case, see [Moving a commit to a different branch](moving-a-commit-to-a-different-branch.md).
+
+## "I made a typo in my commit message"
+
+If it's the most recent commit and you haven't pushed:
+
+```
+git commit --amend -m "The corrected message"
+```
+
+If you've already pushed, see [Amending a commit](amending-a-commit.md) — amending a pushed commit rewrites history and needs a force push.
+
+## "My PR has merge conflicts"
+
+GitHub will show you which files conflict. Pull the target branch into your branch locally, resolve the markers, stage, and commit. The full walkthrough is in [Resolving merge conflicts](resolving-merge-conflicts.md).
+
+## "I accidentally committed a large file (or a build artifact)"
+
+Add the file or directory to [`.gitignore`](creating-a-gitignore-file.md) so it won't sneak back in, then untrack the file:
+
+```
+git rm --cached path/to/large-file
+git commit -m "Stop tracking large-file"
+```
+
+If the file was already pushed and is genuinely huge (hundreds of MB) — especially if GitHub rejected your push — the file needs to be removed from the repository's *history*, not just its latest commit. That's a heavier operation; the tool most people reach for now is [`git-filter-repo`](https://github.com/newren/git-filter-repo). Coordinate with maintainers before rewriting pushed history.
+
+## "I forgot to create a branch — I committed straight to main"
+
+Exactly the same as "I committed to the wrong branch" above. Create a branch at the current HEAD and rewind `main`:
+
+```
+git branch feature-branch
+git reset --hard HEAD~1
+git switch feature-branch
+```
+
+If you already pushed to `main` on your fork, that's usually fine — your fork is yours. Just open the PR from `feature-branch` once you've moved the commit.
+
+## "My fork is behind the upstream repo"
+
+Your fork doesn't automatically update when the original repo changes. See [Keeping your fork synced](keeping-your-fork-synced-with-this-repository.md) — the short version is:
+
+```
+git remote add upstream https://github.com/firstcontributions/first-contributions.git
+git fetch upstream
+git switch main
+git merge upstream/main
+git push origin main
+```
+
+You only need to add the `upstream` remote once.
+
+## "I pushed sensitive data (API key, password, token)"
+
+Treat any pushed secret as **already compromised** — someone may have cloned or forked the repo within seconds.
+
+1. **Rotate the secret first.** Revoke the key/token/password in whichever service issued it, and create a new one. This is the step that actually stops the damage.
+2. Remove the secret from the codebase. Store it in an environment variable or a secrets manager instead, and add it to `.gitignore` if it was in a config file.
+3. Optionally, scrub it from history with [`git-filter-repo`](https://github.com/newren/git-filter-repo). This requires a force push and coordination with collaborators.
+
+Rotating is non-negotiable; scrubbing history without rotating doesn't protect you, because the secret is already out.
+
+## "git push is rejected (non-fast-forward)"
+
+Someone (or you, from another machine) pushed to this branch after you last pulled. Pull their changes first, then push:
+
+```
+git pull --rebase origin <branch-name>
+git push origin <branch-name>
+```
+
+`--rebase` keeps the history linear by replaying your commits on top of theirs. If you hit conflicts during the rebase, resolve them and run `git rebase --continue`.
+
+## "I want to undo a `git reset --hard`"
+
+If you haven't garbage-collected yet (within the last couple of weeks, by default), your commits are still reachable via the reflog:
+
+```
+git reflog
+```
+
+Find the commit hash from *before* your reset, then:
+
+```
+git reset --hard <that-hash>
+```
+
+The reflog is your safety net for almost every "oh no" moment involving a lost commit — check it before assuming work is gone.
+
+## "I have unpushed changes but I need to switch branches"
+
+Use `git stash` to park them:
+
+```
+git stash
+git switch other-branch
+# ... do what you need ...
+git switch original-branch
+git stash pop
+```
+
+See [Stashing a file](stashing-a-file.md) for more.
+
+---
+
+If you're stuck and none of the above matches, open an issue on the project you're contributing to and describe what you tried. Maintainers would much rather help untangle a mistake than see you give up.


### PR DESCRIPTION
## Summary

Adds a FAQ-style troubleshooting guide covering the situations that most often trip up first-time contributors, with the shortest safe fix for each and a link to the deeper guide where one exists.

The repo already has strong *one-topic-one-file* scenario guides. What's missing is a **\"I made a mistake, what do I do?\"** entry point — the file a beginner reaches for when they don't know what the mistake is called yet. This guide tries to be that entry point.

## Note on contribution workflow

`.github/CONTRIBUTING.md` says: *\"If you'd like to suggest a change in the tutorials or the workflow, please raise an issue. We can have a discussion to better understand the problem, get more people involved and make a collective decision.\"*

Happy to **close this PR and open an issue first** if that's the maintainers' preferred flow for new content.

## Scenarios covered

Each has the minimal-viable-fix inline, plus a link to the deeper guide:

- Committed to the wrong branch (→ `moving-a-commit-to-a-different-branch.md`)
- Typo in a commit message (→ `amending-a-commit.md`)
- PR has merge conflicts (→ `resolving-merge-conflicts.md`)
- Accidentally committed a large file or build artifact — includes guidance for files that have already been pushed (points at `git-filter-repo`, flags history-rewrite coordination)
- Forgot to branch and committed straight to `main`
- Fork is behind upstream (→ `keeping-your-fork-synced-with-this-repository.md`)
- **Pushed sensitive data** — leads with *\"rotate the secret first\"* because scrubbing history alone doesn't protect against copies that were already made. This is the advice that most often gets the order wrong in FAQs.
- `git push` rejected (non-fast-forward)
- Undoing a `git reset --hard` via `git reflog`
- Need to switch branches with unpushed changes (→ `stashing-a-file.md`)

Index entry added to `additional-material.md`.

## Test plan

- [x] Every internal link (to the deeper guides) resolves to a file that exists.
- [x] Commands verified locally against a test repo.
- [x] Deliberately does not repeat the content of the deeper guides — this file is a *dispatcher*, not a replacement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)