### PR TITLE
docs(th): update github-desktop-tutorial.th.md to use "main" instead of "master"

### DIFF
--- a/docs/gui-tool-tutorials/translations/github-desktop-tutorial.th.md
+++ b/docs/gui-tool-tutorials/translations/github-desktop-tutorial.th.md
@@ -103,7 +103,7 @@ Commit การเปลี่ยนแปลง:
 
 <img src="https://firstcontributions.github.io/assets/gui-tool-tutorials/github-desktop-tutorial/submit-pull-request.png" alt="submit pull request" />
 
-ในเร็ว ๆ นี้เราจะรวมการเปลี่ยนแปลงทั้งหมดของคุณเข้าไปใน `master` ของโปรเจคนี้ คุณจะได้รับอีเมลแจ้งเตือนเมื่อมีการเปลี่ยนแปลงที่ถูก merge
+ในเร็ว ๆ นี้เราจะรวมการเปลี่ยนแปลงทั้งหมดของคุณเข้าไปใน `main` ของโปรเจคนี้ คุณจะได้รับอีเมลแจ้งเตือนเมื่อมีการเปลี่ยนแปลงที่ถูก merge
 
 ## หลังจากนี้ตองทำอะไรต่อ?
 


### PR DESCRIPTION
## Summary

Brings the Thai translation of the GitHub Desktop tutorial in line with the English version's branch name. The English file was updated previously to say `main`; the Thai translation still said `master`, which contradicts what readers see in GitHub's UI.

## Change

```diff
- ในเร็ว ๆ นี้เราจะรวมการเปลี่ยนแปลงทั้งหมดของคุณเข้าไปใน `master` ของโปรเจคนี้ ...
+ ในเร็ว ๆ นี้เราจะรวมการเปลี่ยนแปลงทั้งหมดของคุณเข้าไปใน `main` ของโปรเจคนี้ ...
```

One-character change. No other Thai content was touched.

## Reviewer

Per `.github/CONTRIBUTING.md`, requesting review from @AimeTPGM as the listed Thai reviewer.

## Test plan

- [x] Only one line changed; surrounding Thai sentence structure preserved.
- [x] No other files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)