### PR TITLE
docs(vn): update github-desktop-tutorial.vn.md to use "main" instead of "master"

### DIFF
--- a/docs/gui-tool-tutorials/translations/github-desktop-tutorial.vn.md
+++ b/docs/gui-tool-tutorials/translations/github-desktop-tutorial.vn.md
@@ -104,7 +104,7 @@ Bây giờ gửi yêu cầu kéo. (Pull request)
 
 <img src="https://firstcontributions.github.io/assets/gui-tool-tutorials/github-desktop-tutorial/submit-pull-request.png" alt="submit pull request" />
 
-Tôi sẽ sớm hợp nhất (merge) tất cả các thay đổi của bạn vào nhánh chủ (master branch) của project này. Bạn sẽ nhận được email thông báo sau khi các thay đổi đã được hợp nhất.
+Tôi sẽ sớm hợp nhất (merge) tất cả các thay đổi của bạn vào nhánh chính (main branch) của project này. Bạn sẽ nhận được email thông báo sau khi các thay đổi đã được hợp nhất.
 
 ## Đi đâu từ đây?
 


### PR DESCRIPTION
## Summary

Brings the Vietnamese translation of the GitHub Desktop tutorial in line with the English version's branch name. The English file was updated previously to say `main`; the Vietnamese translation still said `nhánh chủ (master branch)`, which contradicts what readers see in GitHub's UI.

## Change

```diff
- Tôi sẽ sớm hợp nhất (merge) tất cả các thay đổi của bạn vào nhánh chủ (master branch) của project này.
+ Tôi sẽ sớm hợp nhất (merge) tất cả các thay đổi của bạn vào nhánh chính (main branch) của project này.
```

Both the parenthetical English term (`master branch` → `main branch`) and the Vietnamese gloss (`chủ` → `chính`) updated so the sentence reads naturally.

## What's not changed

The glossary entry near the bottom of the file (\`**Branch**: ...\`) intentionally mentions both `master` and `main` as historical/informational context for readers who may encounter either name in other repos. Left as-is — it's accurate context, not a stale claim about this repo.

## Reviewer

Per `.github/CONTRIBUTING.md`, requesting review from @tranlyvu as the listed Vietnamese reviewer.

## Test plan

- [x] One-line change in the body text; glossary preserved.
- [x] No other files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)