### PR TITLE
docs(fr): update gitkraken-tutorial-fr.md to use "main" instead of "master"

### DIFF
--- a/docs/gui-tool-tutorials/translations/gitkraken-tutorial-fr.md
+++ b/docs/gui-tool-tutorials/translations/gitkraken-tutorial-fr.md
@@ -89,7 +89,7 @@ Cliquez sur le bouton Push dans la barre d'outils.
 
 <img style="float: right;" src="https://firstcontributions.github.io/assets/gui-tool-tutorials/gitkraken-tutorial/gk-origin.png" alt="origin or branch" />
 
-Soumettez les modifications sur la branche origin si vous souhaitez que les modifications se reflètent directement dans la branche master, sinon sélectionnez la branche appropriée que vous souhaitez pousser (push).
+Soumettez les modifications sur la branche origin si vous souhaitez que les modifications se reflètent directement dans la branche main, sinon sélectionnez la branche appropriée que vous souhaitez pousser (push).
 
 
 ## Soumettez vos modifications pour revision (review)
@@ -102,7 +102,7 @@ Maintenant, soumettez la pull request.
 
 <img style="float: right;" src="https://firstcontributions.github.io/assets/gui-tool-tutorials/gitkraken-tutorial/submit-pull-request.png" alt="submit pull request" />
 
-Bientôt, je fusionnerai toutes vos modifications dans la branche master de ce projet. Vous recevrez un e-mail de notification une fois les modifications fusionnées (merge).
+Bientôt, je fusionnerai toutes vos modifications dans la branche main de ce projet. Vous recevrez un e-mail de notification une fois les modifications fusionnées (merge).
 
 ## Que faire ensuite ?
 


### PR DESCRIPTION
## Summary

Brings the French translation of the GitKraken tutorial in line with the English version's branch name. The English file was updated to say `main`; the French translation still said `branche master` in two places.

## Changes

```diff
- ... vous souhaitez que les modifications se reflètent directement dans la branche master ...
+ ... vous souhaitez que les modifications se reflètent directement dans la branche main ...

- Bientôt, je fusionnerai toutes vos modifications dans la branche master de ce projet.
+ Bientôt, je fusionnerai toutes vos modifications dans la branche main de ce projet.
```

## Reviewer

Per `.github/CONTRIBUTING.md`, requesting review from @LePetitRenard as the listed French reviewer.

## Test plan

- [x] Two one-word changes; surrounding French sentence structure preserved.
- [x] No other files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)