### PR TITLE
docs(es): update Spanish GitKraken tutorial to use "main" instead of "master"

### DIFF
--- a/docs/gui-tool-tutorials/translations/Spanish/gitkraken-tutorial-es.md
+++ b/docs/gui-tool-tutorials/translations/Spanish/gitkraken-tutorial-es.md
@@ -98,7 +98,7 @@ Ahora confirma el pull request.
 
 <img style="float: right;" src="https://firstcontributions.github.io/assets/gui-tool-tutorials/gitkraken-tutorial/submit-pull-request.png" alt="submit pull request" />
 
-Pronto estaré fusionando todos sus cambios en la rama master de este proyecto. Recibirás una notificación por correo electrónico cuando los cambios hayan sido fusionados.
+Pronto estaré fusionando todos sus cambios en la rama main de este proyecto. Recibirás una notificación por correo electrónico cuando los cambios hayan sido fusionados.
 
 ## ¿Cuáles son los siguientes pasos?
 

--- a/docs/gui-tool-tutorials/translations/gitkraken-tutorial-es.md
+++ b/docs/gui-tool-tutorials/translations/gitkraken-tutorial-es.md
@@ -98,7 +98,7 @@ Ahora confirma el pull request.
 
 <img style="float: right;" src="https://firstcontributions.github.io/assets/gui-tool-tutorials/gitkraken-tutorial/submit-pull-request.png" alt="submit pull request" />
 
-Pronto estaré fusionando todos sus cambios en la rama master de este proyecto. Recibirás una notificación por correo electrónico cuando los cambios hayan sido fusionados.
+Pronto estaré fusionando todos sus cambios en la rama main de este proyecto. Recibirás una notificación por correo electrónico cuando los cambios hayan sido fusionados.
 
 ## ¿Cuáles son los siguientes pasos?
 


### PR DESCRIPTION
## Summary

Brings the Spanish translation of the GitKraken tutorial in line with the English version's branch name. The English file was updated previously to say `main`; the Spanish translation still said `rama master`.

## Files

The same translation exists in two locations in the repo (byte-identical):
- `docs/gui-tool-tutorials/translations/gitkraken-tutorial-es.md`
- `docs/gui-tool-tutorials/translations/Spanish/gitkraken-tutorial-es.md`

Both are reachable from links in other docs, so this PR updates **both copies in lockstep** to avoid leaving one stale.

## Change

```diff
- Pronto estaré fusionando todos sus cambios en la rama master de este proyecto.
+ Pronto estaré fusionando todos sus cambios en la rama main de este proyecto.
```

## A note about the duplicate-file situation

The translations directory has both flat files (`gitkraken-tutorial-es.md`) AND a `Spanish/` subdirectory containing the same files. This isn't ideal — eventually de-duplicating would prevent exactly this kind of "did I update both?" footgun — but consolidating the directory layout is out of scope for this PR. Flagging in case it's of interest for a future cleanup.

## Reviewer

Per `.github/CONTRIBUTING.md`, requesting review from @yirini or @aaossa as the listed Spanish reviewers.

## Test plan

- [x] Both copies updated identically (one-line change in each).
- [x] No other files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)