### PR TITLE
docs(pt-br): update Portuguese GUI tutorials to use "main" instead of "master"

### DIFF
--- a/docs/gui-tool-tutorials/translations/Portuguese/github-windows-intellij-tutorial.pt_br.md
+++ b/docs/gui-tool-tutorials/translations/Portuguese/github-windows-intellij-tutorial.pt_br.md
@@ -101,7 +101,7 @@ Agora submeta o pull request.
 
 <img src="https://camo.githubusercontent.com/71401ba5551a64aeac3838825a52ce7a7597cd8b54a0d7200d9454e2cbfbb13f/68747470733a2f2f6669727374636f6e747269627574696f6e732e6769746875622e696f2f6173736574732f526561646d652f7375626d69742d70756c6c2d726571756573742e706e67" alt="submit pull request" />
 
-Em breve estarei mesclando todas as suas alterações no branch master deste projeto. Você receberá um e-mail de notificação assim que as alterações forem integradas.
+Em breve estarei mesclando todas as suas alterações no branch main deste projeto. Você receberá um e-mail de notificação assim que as alterações forem integradas.
 
 ## Para onde ir agora?
 
@@ -119,7 +119,7 @@ Agora vamos começar a contribuir para outros projetos, compilamos uma lista de 
 ### [Material Adicional](../../additional-material/translations/Portuguese/additional-material.pt_br.md).
 
 ## Tutoriais usando outras ferramentas
-[Voltar a página principal](https://github.com/firstcontributions/first-contributions/blob/master/translations/README.pt_br.md)
+[Voltar a página principal](https://github.com/firstcontributions/first-contributions/blob/main/docs/translations/README.pt_br.md)
 
 ## Autopromoção
  

--- a/docs/gui-tool-tutorials/translations/Portuguese/github-windows-vs-code-tutorial.pt_br.md
+++ b/docs/gui-tool-tutorials/translations/Portuguese/github-windows-vs-code-tutorial.pt_br.md
@@ -101,7 +101,7 @@ Agora envie a solicitação PR - pull request.
 
 <img src="https://firstcontributions.github.io/assets/Readme/submit-pull-request.png" alt="submit pull request" />
 
-Em breve estarei mesclando todas as suas alterações no branch master deste projeto. Você receberá um e-mail de notificação assim que as alterações forem mescladas.
+Em breve estarei mesclando todas as suas alterações no branch main deste projeto. Você receberá um e-mail de notificação assim que as alterações forem mescladas.
 
 ## Para onde ir a partir daqui?
 

--- a/docs/gui-tool-tutorials/translations/Portuguese/github-windows-vs-code-tutorial_pt_br.md
+++ b/docs/gui-tool-tutorials/translations/Portuguese/github-windows-vs-code-tutorial_pt_br.md
@@ -103,7 +103,7 @@ Agora, submeta o *pull request*.
 
 <img src="https://firstcontributions.github.io/assets/Readme/submit-pull-request.png" alt="submit pull request" />
 
-Breve as suas mudanças serão *mergeadas* na branch `master` desse projeto. Você será notificado por email uma vez que as mudanças forem *mergeadas*.
+Breve as suas mudanças serão *mergeadas* na branch `main` desse projeto. Você será notificado por email uma vez que as mudanças forem *mergeadas*.
 
 ## Para onde ir ?
 
@@ -121,4 +121,4 @@ Você pode se juntar à nossa comunidade no slack, caso precise de alguma ajuda 
 
 ## Tutoriais utilizando outras ferramentas
 
-[Retorne para a página principal](https://github.com/firstcontributions/first-contributions/blob/master/translations/README.pt_br.md)
+[Retorne para a página principal](https://github.com/firstcontributions/first-contributions/blob/main/docs/translations/README.pt_br.md)

--- a/docs/gui-tool-tutorials/translations/Portuguese/github-windows-vs2017-tutorial.pt_br.md
+++ b/docs/gui-tool-tutorials/translations/Portuguese/github-windows-vs2017-tutorial.pt_br.md
@@ -146,4 +146,4 @@ Você pode se juntar à nossa comunidade no slack, caso precise de alguma ajuda 
 ### [Material adicional](../additional-material/git_workflow_scenarios/additional-material.md)
 
 ## Tutoriais utilizando outras ferramentas
-[Retorne para a página principal](https://github.com/firstcontributions/first-contributions/blob/master/translations/README.pt_br.md)
+[Retorne para a página principal](https://github.com/firstcontributions/first-contributions/blob/main/docs/translations/README.pt_br.md)

--- a/docs/gui-tool-tutorials/translations/Portuguese/gitkraken-tutorial.pt-br.md
+++ b/docs/gui-tool-tutorials/translations/Portuguese/gitkraken-tutorial.pt-br.md
@@ -95,7 +95,7 @@ Na barra de ferramentas, clique no botão Push.
 
 <img style="float: right;" src="https://firstcontributions.github.io/assets/gui-tool-tutorials/gitkraken-tutorial/gk-origin.png" alt="origin or branch" />
 
-Se você quer enviar as mudanças direto para branch master, você pode enviar para a branch de origem. Caso contrário, selecione uma branch apropriada para mandar.  
+Se você quer enviar as mudanças direto para branch main, você pode enviar para a branch de origem. Caso contrário, selecione uma branch apropriada para mandar.  
 
 
 ## Envie as suas mudanças para revisão
@@ -108,7 +108,7 @@ Agora envie esse Pull Request.
 
 <img style="float: right;" src="https://firstcontributions.github.io/assets/gui-tool-tutorials/gitkraken-tutorial/submit-pull-request.png" alt="submit pull request" />
 
-Logo irei mesclar todas as suas mudanças na branch master do projeto. Você receberá uma notificação pelo e-mail quando as alterações forem mescladas.
+Logo irei mesclar todas as suas mudanças na branch main do projeto. Você receberá uma notificação pelo e-mail quando as alterações forem mescladas.
 
 ## Onde eu posso ir a partir daqui?
 

--- a/docs/gui-tool-tutorials/translations/github-windows-intellij-tutorial.pt_br.md
+++ b/docs/gui-tool-tutorials/translations/github-windows-intellij-tutorial.pt_br.md
@@ -101,7 +101,7 @@ Agora submeta o pull request.
 
 <img src="https://camo.githubusercontent.com/71401ba5551a64aeac3838825a52ce7a7597cd8b54a0d7200d9454e2cbfbb13f/68747470733a2f2f6669727374636f6e747269627574696f6e732e6769746875622e696f2f6173736574732f526561646d652f7375626d69742d70756c6c2d726571756573742e706e67" alt="submit pull request" />
 
-Em breve estarei mesclando todas as suas alterações no branch master deste projeto. Você receberá um e-mail de notificação assim que as alterações forem integradas.
+Em breve estarei mesclando todas as suas alterações no branch main deste projeto. Você receberá um e-mail de notificação assim que as alterações forem integradas.
 
 ## Para onde ir agora?
 
@@ -119,7 +119,7 @@ Agora vamos começar a contribuir para outros projetos, compilamos uma lista de 
 ### [Material Adicional](../../additional-material/translations/Portugues/additional-material.pt_br.md).
 
 ## Tutoriais usando outras ferramentas
-[Voltar a página principal](https://github.com/firstcontributions/first-contributions/blob/master/translations/README.pt_br.md)
+[Voltar a página principal](https://github.com/firstcontributions/first-contributions/blob/main/docs/translations/README.pt_br.md)
 
 ## Autopromoção
  

--- a/docs/gui-tool-tutorials/translations/github-windows-vs-code-tutorial.pt_br.md
+++ b/docs/gui-tool-tutorials/translations/github-windows-vs-code-tutorial.pt_br.md
@@ -101,7 +101,7 @@ Agora envie a solicitação PR - pull request.
 
 <img src="https://firstcontributions.github.io/assets/Readme/submit-pull-request.png" alt="submit pull request" />
 
-Em breve estarei mesclando todas as suas alterações no branch master deste projeto. Você receberá um e-mail de notificação assim que as alterações forem mescladas.
+Em breve estarei mesclando todas as suas alterações no branch main deste projeto. Você receberá um e-mail de notificação assim que as alterações forem mescladas.
 
 ## Para onde ir a partir daqui?
 

--- a/docs/gui-tool-tutorials/translations/github-windows-vs-code-tutorial_pt_br.md
+++ b/docs/gui-tool-tutorials/translations/github-windows-vs-code-tutorial_pt_br.md
@@ -103,7 +103,7 @@ Agora, submeta o *pull request*.
 
 <img src="https://firstcontributions.github.io/assets/Readme/submit-pull-request.png" alt="submit pull request" />
 
-Breve as suas mudanças serão *mergeadas* na branch `master` desse projeto. Você será notificado por email uma vez que as mudanças forem *mergeadas*.
+Breve as suas mudanças serão *mergeadas* na branch `main` desse projeto. Você será notificado por email uma vez que as mudanças forem *mergeadas*.
 
 ## Para onde ir ?
 
@@ -121,4 +121,4 @@ Você pode se juntar à nossa comunidade no slack, caso precise de alguma ajuda 
 
 ## Tutoriais utilizando outras ferramentas
 
-[Retorne para a página principal](https://github.com/firstcontributions/first-contributions/blob/master/translations/README.pt_br.md)
+[Retorne para a página principal](https://github.com/firstcontributions/first-contributions/blob/main/docs/translations/README.pt_br.md)

--- a/docs/gui-tool-tutorials/translations/github-windows-vs2017-tutorial.pt_br.md
+++ b/docs/gui-tool-tutorials/translations/github-windows-vs2017-tutorial.pt_br.md
@@ -146,4 +146,4 @@ Você pode se juntar à nossa comunidade no slack, caso precise de alguma ajuda 
 ### [Material adicional](../additional-material/git_workflow_scenarios/additional-material.md)
 
 ## Tutoriais utilizando outras ferramentas
-[Retorne para a página principal](https://github.com/firstcontributions/first-contributions/blob/master/translations/README.pt_br.md)
+[Retorne para a página principal](https://github.com/firstcontributions/first-contributions/blob/main/docs/translations/README.pt_br.md)

--- a/docs/gui-tool-tutorials/translations/gitkraken-tutorial.pt-br.md
+++ b/docs/gui-tool-tutorials/translations/gitkraken-tutorial.pt-br.md
@@ -95,7 +95,7 @@ Na barra de ferramentas, clique no botão Push.
 
 <img style="float: right;" src="https://firstcontributions.github.io/assets/gui-tool-tutorials/gitkraken-tutorial/gk-origin.png" alt="origin or branch" />
 
-Se você quer enviar as mudanças direto para branch master, você pode enviar para a branch de origem. Caso contrário, selecione uma branch apropriada para mandar.  
+Se você quer enviar as mudanças direto para branch main, você pode enviar para a branch de origem. Caso contrário, selecione uma branch apropriada para mandar.  
 
 
 ## Envie as suas mudanças para revisão
@@ -108,7 +108,7 @@ Agora envie esse Pull Request.
 
 <img style="float: right;" src="https://firstcontributions.github.io/assets/gui-tool-tutorials/gitkraken-tutorial/submit-pull-request.png" alt="submit pull request" />
 
-Logo irei mesclar todas as suas mudanças na branch master do projeto. Você receberá uma notificação pelo e-mail quando as alterações forem mescladas.
+Logo irei mesclar todas as suas mudanças na branch main do projeto. Você receberá uma notificação pelo e-mail quando as alterações forem mescladas.
 
 ## Onde eu posso ir a partir daqui?
 


### PR DESCRIPTION
## Summary

Brings the Brazilian Portuguese translations of five GUI tutorials in line with the English versions' branch name. All five English files were updated previously to say `main`; the Portuguese translations still said `branch master`, and four backlink URLs pointed at the now-stale `/blob/master/translations/README.pt_br.md`.

## What's wrong

Two classes of stale references:

**1. Inline references to the merge target.** Sentences like *\"em breve estarei mesclando ... no branch master deste projeto\"*. The English equivalents now say `main`.

**2. Backlink URLs in the \"Tutoriais utilizando outras ferramentas\" footer.** They point to `https://github.com/firstcontributions/first-contributions/blob/master/translations/README.pt_br.md` — *doubly* stale: branch is `main` now, and the file moved from `/translations/` to `/docs/translations/`. So those backlinks 404 today.

## Files updated

The translations directory has the same 5 files duplicated across two locations (`translations/` flat and `translations/Portuguese/` subdirectory). Both copies are reachable from various other docs, so this PR updates **both copies in lockstep**:

| File | Lines touched | Notes |
|---|---|---|
| `gitkraken-tutorial.pt-br.md` | 2 | push-target + closing note |
| `github-windows-vs-code-tutorial.pt_br.md` | 1 | closing note |
| `github-windows-vs-code-tutorial_pt_br.md` | 2 | closing note + backlink URL |
| `github-windows-vs2017-tutorial.pt_br.md` | 1 | backlink URL |
| `github-windows-intellij-tutorial.pt_br.md` | 2 | closing note + backlink URL |

Each file is touched in both locations → 10 files modified total.

## A note about the duplicate-file situation

Same flag I added to the Spanish PR: the `translations/` directory has both flat files AND a `Portuguese/` subdirectory holding identical (or near-identical) copies. De-duping the layout would prevent exactly this kind of \"did I update both?\" footgun — but that's its own cleanup, out of scope here.

I noticed one tiny incidental difference between the two IntelliJ copies (the `Portuguese/` copy has a `fassa` typo where the flat copy has the correct `faça`, and points its additional-material link at a non-existent `Portuguese/` subdir instead of `Portugues/`). I did **not** touch those — they're orthogonal to the master->main fix and worth their own discussion.

## Reviewer

Per `.github/CONTRIBUTING.md`, requesting review from @OtacilioN or @gabrielsanttana as the listed Brazilian Portuguese reviewers.

## Test plan

- [x] `git grep master docs/gui-tool-tutorials/translations/ | grep pt_br` → empty after the change.
- [x] All updated backlink URLs point to a file path that exists today (`/blob/main/docs/translations/README.pt_br.md`).
- [x] No content or structure outside the swapped tokens / URLs was touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)