### PR TITLE
Add Daniel Calle to Contributors list

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -1157,6 +1157,7 @@ Christopher Aguilar
 - [Daiwiik Harihar](https://github.com/daiv09)
 - [Daksh Gour](https://github.com/dakshgour)
 - [Dallin Hogenson](https://github.com/dhogenson)
+- [Daniel Calle](https://github.com/danielocalle)
 - [Dan Qiu](https://github.com/danqiu-dev)
 - [Danielynx](https://github.com/danielynx)
 - [Daniel Guo](https://github.com/DiiGii)


### PR DESCRIPTION
Followed tutorial directions and made only the 1 line addition, adding: [Daniel Calle](https://github.com/danielocalle).