### PR TITLE
docs: translate Nigerian Pidgin README alt text

### DIFF
--- a/docs/translations/README.pcm.md
+++ b/docs/translations/README.pcm.md
@@ -106,7 +106,7 @@ If you go to your repository on GitHub, you go see Compare & pull request button
 <img style="float: right;" src="https://firstcontributions.github.io/assets/Readme/compare-and-pull.png" alt="create pull request" />
 Now submit the pull request.
 
-<img style="float: right;" src="https://firstcontributions.github.io/assets/Readme/submit-pull-request.png" alt="submit pull request" />
+<img style="float: right;" src="https://firstcontributions.github.io/assets/Readme/submit-pull-request.png" alt="send pull request" />
 Soon I go merge all your changes into the main branch of this project. You go get notification email once the changes don merge.
 
 ## Where to go from here?


### PR DESCRIPTION
Closes #105374

## Summary

- translate remaining English alt text in README.pcm.md`n- keep the Nigerian Pidgin README more consistent and accessible

## Verification

- updated only image alt text strings