### PR TITLE
docs: translate Pashto README alt text

### DIFF
--- a/docs/translations/README.ps.md
+++ b/docs/translations/README.ps.md
@@ -118,11 +118,11 @@ fatal: Authentication failed for 'https://github.com/&lt;your-username&gt;/first
 - خپل GitHub اکاونټ کې دې ریپوزیټوري ته لاړ شئ.
 - د **Compare & pull request** تڼۍ به ووینئ. پر هغې کلیک وکړئ.
 
-<img style="float: right;" src="https://firstcontributions.github.io/assets/Readme/compare-and-pull.png" alt="create a pull request" />
+<img style="float: right;" src="https://firstcontributions.github.io/assets/Readme/compare-and-pull.png" alt="د pull request جوړول" />
 
 - اوس د pull request غوښتنه وسپارئ.
 
-<img style="float: right;" src="https://firstcontributions.github.io/assets/Readme/submit-pull-request.png" alt="submit pull request" />
+<img style="float: right;" src="https://firstcontributions.github.io/assets/Readme/submit-pull-request.png" alt="pull request استول" />
 
 - له دې وروسته به ستاسو بدلونه د اصلي یا main څانګې سره یوځای شي او ستاسو نوم به د ګډون کوونکو لیست ته اضافه کړل شي.
 


### PR DESCRIPTION
Closes #105319

## Summary

- translate remaining English alt text in README.ps.md`n- improve accessibility for Pashto readers

## Verification

- updated only image alt text strings