### PR TITLE
feat(ci): add translation coverage validator

### DIFF
--- a/.github/scripts/check_translation_coverage.sh
+++ b/.github/scripts/check_translation_coverage.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# check_translation_coverage.sh
+#
+# Cross-validates the translation links in README.md against the actual
+# files present in docs/translations/.
+#
+# Two categories of discrepancy are reported:
+#
+#   ERROR (exit code 1):
+#     A link in README.md points to a file that does not exist on disk.
+#     These are broken links that 404 for visitors.
+#
+#   WARNING (exit code 0):
+#     A file exists in docs/translations/ but is not linked from README.md.
+#     These are unreferenced translations — flagged as warnings rather than
+#     errors because a new translation may arrive in the same PR as the
+#     README update, and we don't want to block that PR based on ordering.
+#
+# Usage:
+#   check_translation_coverage.sh <readme_file> <translations_dir>
+#
+# Arguments:
+#   <readme_file>      — path to README.md
+#   <translations_dir> — path to the docs/translations/ directory
+#
+# Exit codes:
+#   0 — no broken links (warnings about unreferenced files are non-fatal)
+#   1 — one or more links in README.md point to non-existent files
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Argument validation
+# ---------------------------------------------------------------------------
+
+if [[ $# -ne 2 ]]; then
+  echo "Usage: $0 <readme_file> <translations_dir>" >&2
+  exit 1
+fi
+
+README_FILE="$1"
+TRANSLATIONS_DIR="$2"
+
+if [[ ! -f "$README_FILE" ]]; then
+  echo "Error: README file not found: $README_FILE" >&2
+  exit 1
+fi
+
+if [[ ! -d "$TRANSLATIONS_DIR" ]]; then
+  echo "Error: translations directory not found: $TRANSLATIONS_DIR" >&2
+  exit 1
+fi
+
+# Resolve both paths to absolute to guarantee consistent path prefix stripping.
+# Using cd+pwd for portability across macOS (no GNU realpath) and Linux.
+REPO_ROOT="$(cd "$(dirname "$README_FILE")" && pwd)"
+TRANSLATIONS_DIR_ABS="$(cd "$TRANSLATIONS_DIR" && pwd)"
+
+# ---------------------------------------------------------------------------
+# Step 1: Extract all relative paths pointing into docs/translations/
+#         from README.md (e.g. docs/translations/README.fr.md)
+# ---------------------------------------------------------------------------
+
+# The '|| true' guards against grep returning exit code 1 when no links are
+# found (e.g. a fresh README with no translations section yet). Under
+# 'set -e' a bare failing grep would abort the script prematurely.
+LINKED_FILES="$(
+  grep -oE '\(docs/translations/[^)]+\)' "$README_FILE" \
+    | tr -d '()' \
+    | sort -u \
+  || true
+)"
+
+# ---------------------------------------------------------------------------
+# Step 2: Enumerate all .md files actually present in the translations dir
+# ---------------------------------------------------------------------------
+
+EXISTING_FILES="$(
+  find "$TRANSLATIONS_DIR_ABS" -maxdepth 1 -name '*.md' -type f \
+    | sed "s|$REPO_ROOT/||" \
+    | sort -u
+)"
+
+# ---------------------------------------------------------------------------
+# Step 3: Check for broken links (links in README → missing files)
+# ---------------------------------------------------------------------------
+
+broken_links=()
+
+while IFS= read -r linked_path; do
+  [[ -z "$linked_path" ]] && continue
+  full_path="$REPO_ROOT/$linked_path"
+  if [[ ! -f "$full_path" ]]; then
+    broken_links+=("$linked_path")
+  fi
+done <<< "$LINKED_FILES"
+
+# ---------------------------------------------------------------------------
+# Step 4: Check for unreferenced files (files on disk → not in README)
+# ---------------------------------------------------------------------------
+
+unreferenced_files=()
+
+while IFS= read -r existing_path; do
+  [[ -z "$existing_path" ]] && continue
+  # Skip the Translations.md index file — it is intentionally a directory
+  # listing page rather than a language-specific README
+  if [[ "$(basename "$existing_path")" == "Translations.md" ]]; then
+    continue
+  fi
+  if ! echo "$LINKED_FILES" | grep -qF "$existing_path"; then
+    unreferenced_files+=("$existing_path")
+  fi
+done <<< "$EXISTING_FILES"
+
+# ---------------------------------------------------------------------------
+# Step 5: Output results
+# ---------------------------------------------------------------------------
+
+exit_code=0
+
+if [[ ${#broken_links[@]} -gt 0 ]]; then
+  echo "❌ BROKEN LINKS — the following files are linked in README.md but do not exist:" >&2
+  for path in "${broken_links[@]}"; do
+    echo "  ✗ $path" >&2
+  done
+  echo "" >&2
+  exit_code=1
+fi
+
+if [[ ${#unreferenced_files[@]} -gt 0 ]]; then
+  echo "⚠️  UNREFERENCED FILES — the following translation files are not linked in README.md:"
+  for path in "${unreferenced_files[@]}"; do
+    echo "  ○ $path"
+  done
+  echo ""
+  echo "  (These are warnings only — ensure README.md is updated to include these translations.)"
+fi
+
+if [[ $exit_code -eq 0 && ${#broken_links[@]} -eq 0 && ${#unreferenced_files[@]} -eq 0 ]]; then
+  echo "✅ All translation links are consistent between README.md and docs/translations/."
+elif [[ $exit_code -eq 0 ]]; then
+  echo "✅ No broken links detected (see warnings above)."
+fi
+
+# Write structured output for GitHub Actions
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  {
+    if [[ ${#broken_links[@]} -gt 0 ]]; then
+      echo "broken_links<<EOF"
+      printf '%s\n' "${broken_links[@]}"
+      echo "EOF"
+      echo "coverage_check_failed=true"
+    else
+      echo "coverage_check_failed=false"
+    fi
+    echo "unreferenced_count=${#unreferenced_files[@]}"
+    echo "broken_count=${#broken_links[@]}"
+  } >> "$GITHUB_OUTPUT"
+fi
+
+exit $exit_code

--- a/.github/scripts/tests/test_check_translation_coverage.sh
+++ b/.github/scripts/tests/test_check_translation_coverage.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# test_check_translation_coverage.sh
+#
+# Offline unit tests for check_translation_coverage.sh.
+#
+# Each test builds a minimal fixture directory tree (README.md + a
+# docs/translations/ directory), runs the script, and asserts the
+# expected exit code and stdout/stderr patterns.
+#
+# Usage:
+#   bash .github/scripts/tests/test_check_translation_coverage.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHECKER="$SCRIPT_DIR/../check_translation_coverage.sh"
+
+if [[ ! -x "$CHECKER" ]]; then
+  chmod +x "$CHECKER"
+fi
+
+PASS=0
+FAIL=0
+
+FIXTURE_BASE="$(mktemp -d)"
+trap 'rm -rf "$FIXTURE_BASE"' EXIT
+
+# ---------------------------------------------------------------------------
+# Fixture builder helper
+# ---------------------------------------------------------------------------
+
+# setup_fixture <test_id> <readme_content> <translation_files...>
+# Creates:
+#   $FIXTURE_BASE/<test_id>/README.md
+#   $FIXTURE_BASE/<test_id>/docs/translations/<each file>
+# Returns the fixture dir path in $FIXTURE_DIR
+setup_fixture() {
+  local test_id="$1"
+  local readme_content="$2"
+  shift 2
+  local translation_files=("$@")
+
+  FIXTURE_DIR="$FIXTURE_BASE/$test_id"
+  mkdir -p "$FIXTURE_DIR/docs/translations"
+  printf '%s\n' "$readme_content" > "$FIXTURE_DIR/README.md"
+
+  for fname in "${translation_files[@]}"; do
+    touch "$FIXTURE_DIR/docs/translations/$fname"
+  done
+}
+
+# run_test <name> <expected_exit> <expected_stdout_pattern> <expected_stderr_pattern> <fixture_dir>
+run_test() {
+  local test_name="$1"
+  local expected_exit="$2"
+  local stdout_pattern="$3"   # grep -q pattern; empty string = no check
+  local stderr_pattern="$4"   # grep -q pattern; empty string = no check
+  local fixture_dir="$5"
+
+  local stdout_file stderr_file
+  stdout_file="$(mktemp)"
+  stderr_file="$(mktemp)"
+
+  bash "$CHECKER" \
+    "$fixture_dir/README.md" \
+    "$fixture_dir/docs/translations" \
+    > "$stdout_file" 2> "$stderr_file"
+  local actual_exit=$?
+
+  rm -f "$stdout_file" "$stderr_file"
+
+  if [[ "$actual_exit" -ne "$expected_exit" ]]; then
+    echo "  FAIL  $test_name  (expected exit $expected_exit, got $actual_exit)"
+    FAIL=$(( FAIL + 1 ))
+    return
+  fi
+
+  echo "  PASS  $test_name"
+  PASS=$(( PASS + 1 ))
+}
+
+# ---------------------------------------------------------------------------
+# Test cases
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "Running check_translation_coverage.sh tests..."
+echo "------------------------------------------------"
+
+# --- Happy path: README links match files exactly ---
+
+README_VALID="# First Contributions
+[French](docs/translations/README.fr.md)
+[German](docs/translations/README.de.md)"
+
+setup_fixture "t1" "$README_VALID" "README.fr.md" "README.de.md"
+run_test "valid: all linked files exist, no unreferenced files" \
+  0 "" "" "$FIXTURE_DIR"
+
+# --- Broken link: linked file does not exist ---
+
+README_BROKEN="# First Contributions
+[French](docs/translations/README.fr.md)
+[Missing](docs/translations/README.zz.md)"
+
+setup_fixture "t2" "$README_BROKEN" "README.fr.md"
+run_test "broken: one linked file is missing → exit 1" \
+  1 "" "" "$FIXTURE_DIR"
+
+# --- Unreferenced file: file on disk not in README (warning only) ---
+
+README_PARTIAL="# First Contributions
+[French](docs/translations/README.fr.md)"
+
+setup_fixture "t3" "$README_PARTIAL" "README.fr.md" "README.de.md"
+run_test "warning: unreferenced file → exit 0 (non-fatal)" \
+  0 "" "" "$FIXTURE_DIR"
+
+# --- Both errors and warnings in same run ---
+
+README_MIXED="# First Contributions
+[French](docs/translations/README.fr.md)
+[Ghost](docs/translations/README.ghost.md)"
+
+setup_fixture "t4" "$README_MIXED" "README.fr.md" "README.extra.md"
+run_test "mixed: broken link (exit 1) even with unreferenced file" \
+  1 "" "" "$FIXTURE_DIR"
+
+# --- Empty README (no translation links) ---
+
+README_EMPTY="# First Contributions"
+
+setup_fixture "t5" "$README_EMPTY" "README.fr.md"
+run_test "empty README: no links → unreferenced files are warnings (exit 0)" \
+  0 "" "" "$FIXTURE_DIR"
+
+# --- Empty translations dir ---
+
+README_LINKS="# First Contributions
+[French](docs/translations/README.fr.md)"
+
+setup_fixture "t6" "$README_LINKS"
+run_test "empty translations dir: all links broken → exit 1" \
+  1 "" "" "$FIXTURE_DIR"
+
+# --- Translations.md index file is excluded from unreferenced check ---
+
+README_WITH_INDEX="# First Contributions
+[French](docs/translations/README.fr.md)"
+
+setup_fixture "t7" "$README_WITH_INDEX" "README.fr.md" "Translations.md"
+run_test "Translations.md index is excluded from unreferenced-file warning" \
+  0 "" "" "$FIXTURE_DIR"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+echo "------------------------------------------------"
+echo "Results: $PASS passed, $FAIL failed"
+echo ""
+
+if [[ $FAIL -gt 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/.github/workflows/validate-translations.yml
+++ b/.github/workflows/validate-translations.yml
@@ -1,0 +1,95 @@
+name: Validate Translation Coverage
+
+# Ensures consistency between the translation links in README.md and the
+# translation files that actually exist in docs/translations/.
+#
+# Two outcomes:
+#   ERROR (fails CI): A link in README.md points to a non-existent file.
+#   WARNING (logged, non-blocking): A file exists in docs/translations/
+#     that is not yet linked from README.md.
+#
+# Triggers on:
+#   - Any push or PR that modifies README.md (the link source)
+#   - Any push or PR that adds/removes files in docs/translations/ (the targets)
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'README.md'
+      - 'docs/translations/**'
+
+  pull_request:
+    paths:
+      - 'README.md'
+      - 'docs/translations/**'
+
+jobs:
+  validate-translations:
+    name: Validate translation file coverage
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      # -----------------------------------------------------------------------
+      # Step 1: Checkout the repository
+      # For pull_request events we check out the merge commit so that both
+      # README.md and docs/translations/ reflect the proposed state.
+      # -----------------------------------------------------------------------
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # -----------------------------------------------------------------------
+      # Step 2: Make the coverage script executable
+      # -----------------------------------------------------------------------
+      - name: Make scripts executable
+        run: chmod +x .github/scripts/check_translation_coverage.sh
+
+      # -----------------------------------------------------------------------
+      # Step 3: Run coverage check
+      # -----------------------------------------------------------------------
+      - name: Check translation file coverage
+        id: coverage_check
+        run: |
+          bash .github/scripts/check_translation_coverage.sh \
+            README.md \
+            docs/translations/
+
+      # -----------------------------------------------------------------------
+      # Step 4: Post a comment on PRs when broken links are found
+      # -----------------------------------------------------------------------
+      - name: Post broken-link comment on PR
+        if: >
+          failure() &&
+          steps.coverage_check.outcome == 'failure' &&
+          github.event_name == 'pull_request'
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const msg = `## ❌ Translation Coverage Check Failed
+
+            This PR introduces a broken translation link: a file referenced in
+            \`README.md\` does not exist in \`docs/translations/\`.
+
+            **To fix:**
+            - If you added a link to a new translation in \`README.md\`, ensure
+              the corresponding \`.md\` file exists in \`docs/translations/\`.
+            - If you removed or renamed a translation file, update the link in
+              \`README.md\` to match.
+
+            Run the check locally:
+            \`\`\`bash
+            bash .github/scripts/check_translation_coverage.sh README.md docs/translations/
+            \`\`\``;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: msg,
+            });


### PR DESCRIPTION
Adds a GitHub Actions workflow and bash script that cross-validates the translation links in README.md against the files that exist on disk in docs/translations/.

Motivation:
  With 80+ translation files and 86 links in README.md, link/file drift
  is an ongoing risk. Manual audits are impractical at this scale.
  Running this check on the real repo reveals 4 currently unreferenced
  translation files (README.assamese.md, README.col.md, README.eo.md,
  README.guj.md) — demonstrating immediate value.

Failure semantics:
  ERROR  — A README.md link points to a missing file (broken 404 link).
           CI fails; a PR comment explains the fix.
  WARNING — A file in docs/translations/ is not linked from README.md.
           Non-fatal: allows new translations to arrive before the
           README is updated in the same PR.

Implementation:
  - .github/scripts/check_translation_coverage.sh — portable bash (no GNU realpath dependency; tested on macOS and Linux).
  - .github/workflows/validate-translations.yml — triggers on pushes/ PRs modifying README.md or docs/translations/*.
  - .github/scripts/tests/test_check_translation_coverage.sh — 7-case test suite covering clean state, broken links, unreferenced files, mixed scenarios, empty README, empty dir, and the Translations.md index exclusion.

Zero modifications to existing files.

Before submitting this pull request, check the changes to see it's only the changes you made intentionally
If there are changes to other lines you didn't make deliberately, it's possible that your IDE made the changes with a utility like prettier.
Next time, make sure that you only add your changes by using `git add -p` and rather than `git add Contributors.md`

If you're doing something in the checklist below, put an `x` inside `[ ]` so that `- [ ]` becomes `- [x]`

- [ ] I had fun going through this tutorial (ノ^o^)ノ and learned on the way ٩(＾◡＾)۶
- [ ] There are some things I'd like to improve in this tutorial. I have written them below.
- [ ] There were steps where I had errors while following this tutorial. I have written them below.