### PR TITLE
Add parlox to Contributors list

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -2589,6 +2589,7 @@ Alejandro Alfaro
 - [oona34](https://github.com/oona34)
 - [oscar](https://github.com/olp0678/first-contributions)
 - [eniyanyosuva](https://github.com/Eniyanyosuva)
+- [parlox](https://github.com/parlox)
 - [payal rawat](https://github.com/payalrawat369)
 - [peanut-butter-wafer-lover](https://github.com/peanut-butter-wafer-lover)
 - [pomv](https://github.com/pomv)


### PR DESCRIPTION
Adding myself (parlox) to the contributors list as part of the first-contributions tutorial.