### PR TITLE
Fix: update contribution link in Ewe README

### DIFF
--- a/docs/translations/README.ewe.md
+++ b/docs/translations/README.ewe.md
@@ -141,4 +141,4 @@ Esia mehiã o, gake alɔdzedɔwɔƒea ƒe ŋkɔ ɖee fia be eƒe taɖodzinua nye
 
 ## Afikae míayi emegbe?
 
-Àte ŋu awɔ ɖeka kple míaƒe ƒuƒoƒoa hã le Slack nenye be èhiã kpekpeɖeŋu alo nyabiase aɖewo le asiwò.  [Wɔ ɖeka kple ƒuƒoƒoa le Slack dzi](https://join.slack.com/t/firstcontributors/shared_invite/zt-1hg51qkgm-Xc7HxhsiPYNN3ofX2_I8FA)
+Àte ŋu awɔ ɖeka kple míaƒe ƒuƒoƒoa hã nenye be èhiã kpekpeɖeŋu alo nyabiase aɖewo le asiwò.  [Code Contributions](https://github.com/firstcontributions/first-contributions)


### PR DESCRIPTION
### 🛠️ Fixed: Updated contribution link in Ewe README

Replaced the Slack link in the "Where to go from here" section with the correct code contributions link, aligning it with the main README.

Addresses #104245

---

* [x] I had fun going through this tutorial (ノ^o^)ノ and learned on the way ٩(＾◡＾)۶
* [ ] There are some things I'd like to improve in this tutorial.
* [ ] There were steps where I had errors while following this tutorial.
