### PR TITLE
Update link for contributing projects in README

### DIFF
--- a/docs/translations/README.tm.md
+++ b/docs/translations/README.tm.md
@@ -130,7 +130,7 @@ Gutlaýas! Siz standart goşant goşujy hökmünde kän gabat gelinýän _forkla
 
 Eden goşandyňyza begeniň we dostlaryňyz bilen paýlaşyň!
 
-[Bu baglanma](https://firstcontributions.github.io/#social-share) arkaly hem birnäçe gyzykly proýektlere öz goşandyňyzy goşup bilýäňiz.
+[Bu baglanma](https://github.com/roshanjossey/code-contributions) arkaly hem birnäçe gyzykly proýektlere öz goşandyňyzy goşup bilýäňiz.
 
 
 


### PR DESCRIPTION
Addresses #104821.

This updates the Turkmen README's next-steps link to point to the Code Contributions repository instead of the old First Contributions social-share page.