### PR TITLE
Fix broken Visual Studio 2017 tutorial icon

### DIFF
--- a/docs/gui-tool-tutorials/github-windows-vs2017-tutorial.md
+++ b/docs/gui-tool-tutorials/github-windows-vs2017-tutorial.md
@@ -4,7 +4,7 @@
 
 # First Contributions
 
-|<img alt="Visual Studio 2017" src="https://upload.wikimedia.org/wikipedia/commons/thumb/6/61/Visual_Studio_2017_logo_and_wordmark.svg/2000px-Visual_Studio_2017_logo_and_wordmark.svg.png" width="200">|Visual Studio 2017 Edition|
+|<img alt="Visual Studio 2017" src="https://upload.wikimedia.org/wikipedia/commons/c/cd/Visual_Studio_2017_Logo.svg" width="200">|Visual Studio 2017 Edition|
 |---|---|
 
 It's hard. It's always hard the first time you do something. Especially when you are collaborating, making mistakes isn't a comfortable thing. But open source is all about collaboration & working together. We wanted to simplify the way new open-source contributors learn & contribute for the first time.


### PR DESCRIPTION
## Summary
- replace the broken Visual Studio 2017 tutorial image URL with a working Wikimedia SVG URL
- keep the change limited to the tutorial header icon

## Verification
- confirmed the old thumbnail URL returns HTTP 400
- confirmed the replacement SVG URL returns HTTP 200

Related to #116496