### PR TITLE
Add feedback comment for multi-line Contributors.md PRs

### DIFF
--- a/.github/workflows/auto-pr-merge.yml
+++ b/.github/workflows/auto-pr-merge.yml
@@ -176,6 +176,21 @@ jobs:
               // Set GitHub Action as failed
               core.setFailed(error.message);
             }
+            
+      # Post comment when Contributors.md has multiple line changes
+      - name: Post comment for multiple line changes
+        if: env.only_contributors == 'true' && env.one_line_change != 'true'
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.issues.createComment({
+             owner: context.repo.owner,
+             repo: context.repo.repo,
+             issue_number: context.issue.number,
+             body: "Thank you for your pull request! This PR modifies Contributors.md with multiple line changes, so a maintainer will review it manually."
+             })
+
 
       # Post a comment on the pull request if it was not merged automatically
       - name: Post comment on PR if not merged automatically


### PR DESCRIPTION
Fixes the workflow gap where PRs modifying only Contributors.md with multiple line changes receive no feedback.

This adds a workflow step that posts a review message when:
- only Contributors.md is modified
- but the PR contains multiple line changes

Addresses #116968

---

Before submitting this pull request, check the changes to see it's only the changes you made intentionally
If there are changes to other lines you didn't make deliberately, it's possible that your IDE made the changes with a utility like prettier.
Next time, make sure that you only add your changes by using `git add -p` and rather than `git add Contributors.md`

If you're doing something in the checklist below, put an `x` inside `[ ]` so that `- [ ]` becomes `- [x]`

- [ x] I had fun going through this tutorial (ノ^o^)ノ and learned on the way ٩(＾◡＾)۶
- [ ] There are some things I'd like to improve in this tutorial. I have written them below.
- [ ] There were steps where I had errors while following this tutorial. I have written them below.