### PR TITLE
Add feedback comment for multiline Contributors.md PRs

### DIFF
--- a/.github/workflows/auto-pr-merge.yml
+++ b/.github/workflows/auto-pr-merge.yml
@@ -176,6 +176,20 @@ jobs:
               // Set GitHub Action as failed
               core.setFailed(error.message);
             }
+                    # Comment when Contributors.md has multiple line changes
+                    - name: Comment on multi-line Contributors.md changes
+                      if: env.only_contributors == 'true' && env.one_line_change == 'false'
+                      uses: actions/github-script@v6
+                      with:
+                        script: |
+                          await github.rest.issues.createComment({
+                            owner: context.repo.owner,
+                            repo: context.repo.repo,
+                            issue_number: context.issue.number,
+                            body: "Thank you for your pull request! This PR modifies Contributors.md with multiple line changes, so it was not auto-merged. A maintainer will review it shortly."
+                          })
+                        github-token: ${{ secrets.GITHUB_TOKEN }}
+
 
       # Post a comment on the pull request if it was not merged automatically
       - name: Post comment on PR if not merged automatically


### PR DESCRIPTION
## Description

This PR fixes the workflow logic gap where contributors receive no feedback when a PR modifies only `Contributors.md` with multiple line changes.

### Changes made

* Added a new conditional step in `auto-pr-merge.yml`
* The workflow now posts a comment when:

  * `only_contributors == true`
  * `one_line_change == false`

### Why

Previously, neither the merge step nor the existing comment step would run in this scenario, causing contributors to receive no response.

Fixes #116968
