### PR TITLE
Make explorer instructions clearer for first-time contributors

### DIFF
--- a/docs/gui-tool-tutorials/github-windows-vs-code-tutorial.md
+++ b/docs/gui-tool-tutorials/github-windows-vs-code-tutorial.md
@@ -80,7 +80,7 @@ The file explorer displays all files which were changed after the last commit. B
 
 <img src="https://firstcontributions.github.io/assets/gui-tool-tutorials/github-windows-vs-code-tutorial/vscode-2018-08-commit1.png" alt="Stashed Files">
 
-Type something in the line on top of the explorer and press the checkmark. The changes are now committed to your local copy. Now the changes have to be pushed back to GitHub.
+Replace the top explorer line text with 'Add your-name to Contributors list' and press the checkmark. The changes are now committed to your local copy. Now the changes have to be pushed back to GitHub.
 
 <img src="https://firstcontributions.github.io/assets/gui-tool-tutorials/github-windows-vs-code-tutorial/vscode-2018-08-push.png" alt="Stashed Files">
 


### PR DESCRIPTION
Addresses #118291

Made the explorer instruction more explicit by specifying what text should be entered, instead of the vague "Type something" wording.