### PR TITLE
Add Death Legion Team to Contributors

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -1497,3 +1497,4 @@ varshini
 - [Kevin Yang](https://github.com/kevyang267)
 [Aditya Vinayak Sahu](https://github.com/sahu-adityaVinayak)
 - [wailer-zero](https://github.com/wailer-zero)
+Death Legion Team - Sri Lanka


### PR DESCRIPTION
Adding Death Legion Team from Sri Lanka to the contributors list.