### PR TITLE
Fix Uzbek README auth URL angle brackets

### DIFF
--- a/docs/translations/README.uz.md
+++ b/docs/translations/README.uz.md
@@ -113,7 +113,7 @@ git push origin -u new_branch # siz yaratgan yangi branch
 <pre>
   remote: Support for password authentication was removed on August 13, 2021. Please use a personal access token instead.
   remote: Please see https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/ for more information.
-  fatal: Authentication failed for 'https://github.com/<your-username>/first-contributions.git/'
+  fatal: Authentication failed for 'https://github.com/&lt;your-username&gt;/first-contributions.git/'
 </pre>
 
 Akkountingizga SSH kalit yaratish va konfiguratsiya qilish uchun [GitHub qo'llanma](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account) ga o'ting.


### PR DESCRIPTION
## Summary
- Replaced raw angle-bracket placeholders in `docs/translations/README.uz.md` so `fatal: Authentication failed` is rendered correctly in markdown for the Uzbek translation.

Resolves #118507

## Validation
- Verified the updated line now contains `&lt;your-username&gt;` in:
  - `docs/translations/README.uz.md`
