### PR TITLE
Add Benjamin Wingerter to Contributors

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -1607,3 +1607,5 @@ varshini
 - [Achintya Singh](https://github.com/furygamingind24-art)
 - [Deepankar Singh](https://github.com/deepankarsingh106)
 - [Nayf Serag](https://github.com/nayefserag)
+- [Benjamin Wingerter](https://github.com/wingerter)
+- next here


### PR DESCRIPTION
Following the first-contributions tutorial: adding my name to Contributors.md as my first practice contribution. Thanks for maintaining this beginner-friendly project!