### PR TITLE
Fix Korean CLI tutorial angle brackets

### DIFF
--- a/docs/cli-tool-tutorials/github-cli-tutorial-ko.md
+++ b/docs/cli-tool-tutorials/github-cli-tutorial-ko.md
@@ -75,7 +75,7 @@ git push origin -u your-branch-name
 - ### 인증 오류
      <pre>remote: Support for password authentication was removed on August 13, 2021. Please use a personal access token instead.
   remote: Please see https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/ for more information.
-  fatal: Authentication failed for 'https://github.com/<your-username>/first-contributions.git/'</pre>
+  fatal: Authentication failed for 'https://github.com/&lt;your-username&gt;/first-contributions.git/'</pre>
   SSH키 생성이 필요합니다. [GitHub's tutorial](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account)를 참고하세요.
 
 </details>


### PR DESCRIPTION
Resolves #118515

## What was changed

Fixed the Korean CLI tutorial so that `<your-username>` is displayed correctly in the authentication error example.

The angle brackets were escaped as `&lt;your-username&gt;` to prevent GitHub Markdown from treating them as an HTML tag.

## Checklist

- [x] I had fun going through this tutorial (ノ^o^)ノ and learned on the way ٩(＾◡＾)۶
- [x] There are some things I'd like to improve in this tutorial. I have written them below.
- [ ] There were steps where I had errors while following this tutorial. I have written them below.

## Improvement

In the Korean CLI tutorial, `<your-username>` was not displayed correctly inside the authentication error example.  
This PR fixes the rendering issue by escaping the angle brackets.