### PR TITLE
Update github-cli-tutorial-sinhala.md

### DIFF
--- a/docs/cli-tool-tutorials/github-cli-tutorial-sinhala.md
+++ b/docs/cli-tool-tutorials/github-cli-tutorial-sinhala.md
@@ -75,7 +75,7 @@ git push origin -u your-branch-name
 - ### Authentication Error
      <pre>දුරස්ථ: මුරපද සත්‍යාපනය සඳහා වන සහාය 2021 අගෝස්තු 13 දින ඉවත් කරන ලදී. කරුණාකර ඒ වෙනුවට පුද්ගලික ප්‍රවේශ ටෝකනයක් භාවිතා කරන්න.
   දුරස්ථ: කරුණාකර වැඩි විස්තර සඳහා https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/ බලන්න.
-  මාරක: 'https://github.com/<your-username>/first-contributions.git/'</pre> සඳහා සත්‍යාපනය අසාර්ථක විය
+  මාරක: 'https://github.com/&lt;your-username&gt;/first-contributions.git/' </pre> සඳහා සත්‍යාපනය අසාර්ථක විය
   [GitHub හි නිබන්ධනය](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account) වෙත යන්න ඔබගේ ගිණුමට SSH යතුරක් උත්පාදනය කිරීම සහ වින්‍යාස කිරීම.
   
 </details>     


### PR DESCRIPTION
# Pull Request: Replace angle brackets with HTML entities in Sinhala CLI tutorial

## PR Details
- **Repository:** firstcontributions/first-contributions
- **Base Branch:** main
- **Head Branch:** Iqrima:Second-contributions:main
- **Comparison URL:** https://github.com/firstcontributions/first-contributions/compare/main...Iqrima:Second-contributions:main?expand=1
- **Issue:** Resolves #118517

---

## Overview

This pull request fixes a display issue in the **Sinhala GitHub CLI tutorial** by replacing angle brackets with HTML entities in the authentication error message section. The angle brackets were being interpreted as HTML tags by GitHub's markdown renderer, causing the placeholder text `<your-username>` to disappear or render incorrectly.

---

## Files Changed

### `docs/cli-tool-tutorials/github-cli-tutorial-sinhala.md`

#### Line 78 - Authentication Error Section

**Before:**
```html
მაარაკი: 'https://github.com/<your-username>/first-contributions.git/'</pre> සඳහා සත්‍යාපනය අසාර්ථක විය