### PR TITLE
Fix error code formatting in Hindi CLI tutorial

### DIFF
--- a/docs/cli-tool-tutorials/translations/github-cli-tutorial.hi.md
+++ b/docs/cli-tool-tutorials/translations/github-cli-tutorial.hi.md
@@ -67,11 +67,17 @@ git switch -c add-जॉन-डूई
 
 `your-branch-name` आपके द्वारा पहले बनाई गई शाखा के नाम से बदलकर।
 
-<details><summary> <strong>यदि आपको पुश करते समय कोई त्रुटि मिलती है, तो यहां क्लिक करें:</strong></summary></details>
+<details><summary> <strong>यदि आपको पुश करते समय कोई त्रुटि मिलती है, तो यहां क्लिक करें:</strong></summary>
 
 - ### प्रमाणीकरण त्रुटि
-       रिमोट: 13 अगस्त, 2021 को पासवर्ड प्रमाणीकरण के लिए समर्थन हटा दिया गया था। कृपया इसके बजाय एक व्यक्तिगत एक्सेस टोकन का उपयोग करें। दूरस्थ: अधिक जानकारी के लिए कृपया https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/ देखें। घातक: 'https://github.com/' के लिए प्रमाणीकरण विफल /प्रथम-योगदान.गिट/'
+       <pre>
+       रिमोट: 13 अगस्त, 2021 को पासवर्ड प्रमाणीकरण के लिए समर्थन हटा दिया गया था। कृपया इसके बजाय एक व्यक्तिगत एक्सेस टोकन का उपयोग करें। 
+       दूरस्थ: अधिक जानकारी के लिए कृपया https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/ देखें। 
+       घातक: 'https://github.com/' के लिए प्रमाणीकरण विफल /प्रथम-योगदान.गिट/'
+       </pre>
   अपने खाते में SSH कुंजी बनाने और कॉन्फ़िगर करने के लिए [GitHub के ट्यूटोरियल](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account) पर जाएं।
+
+  </details>
 
 # समीक्षा के लिए अपने परिवर्तन सबमिट करें
 


### PR DESCRIPTION
Fixed the formatting of the authentication error section in the Hindi translation of the GitHub CLI tutorial.
The error messages are now displayed with proper line breaks inside the code block, matching the intended format.

Resolves #118476