### PR TITLE
fix: replace angle brackets in Simplified Chinese translation of README

### DIFF
--- a/docs/translations/README.zh-cn.md
+++ b/docs/translations/README.zh-cn.md
@@ -91,7 +91,7 @@ git push origin <分支的名称>
 - ### Authentication Error
      <pre>remote: Support for password authentication was removed on August 13, 2021. Please use a personal access token instead.
   remote: Please see https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/ for more information.
-  fatal: Authentication failed for 'https://github.com/<your-username>/first-contributions.git/'</pre>
+  fatal: Authentication failed for 'https://github.com/&lt;your-username&gt;/first-contributions.git/'</pre>
   去 [GitHub's tutorial](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account) 学习如何生成新的 SSH 密匙以及配置。
 
 </details>


### PR DESCRIPTION
## Problem

In the collapsible section of the Simplified Chinese README (`docs/translations/README.zh-cn.md`), the characters `<` and `>` were used in the authentication error example, causing `<your-username>` to be treated as HTML code and therefore not visible.

## Fix

Replaced `<` with `&lt;` and `>` with `&gt;` in the authentication error line so that `<your-username>` renders correctly.

Resolves #118509