### PR TITLE
Replace angle brackets in Vietnamese README

### DIFF
--- a/docs/translations/README.vn.md
+++ b/docs/translations/README.vn.md
@@ -92,7 +92,7 @@ thay thế `<tên-nhánh-của-bạn>` với tên của nhánh bạn tạo ra tr
 - ### Lỗi xác thực (Authentication Error)
      <pre>remote: Support for password authentication was removed on August 13, 2021. Please use a personal access token instead.
   remote: Please see https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/ for more information.
-  fatal: Authentication failed for 'https://github.com/<your-username>/first-contributions.git/'</pre>
+  fatal: Authentication failed for 'https://github.com/&lt;your-username&gt;/first-contributions.git/'</pre>
   Truy cập vào [GitHub's tutorial](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account) về việc tạo cấu hình khóa SSH cho tài khoản của bạn.
 
 </details>


### PR DESCRIPTION
## Summary
Replace angle brackets `<` and `>` with HTML entities `&lt;` and `&gt;` in the Vietnamese README to fix display issue.

## Problem
The angle brackets in the error message cause `<your-username>` to be interpreted as HTML tags, making them invisible.

## Solution
- Find the line containing `fatal: Authentication failed...`
- Replace `<` with `&lt;`
- Replace `>` with `&gt;`

## Related Issue
Resolves #118508 