### PR TITLE
fix angle brackets in portuguese

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -12,6 +12,7 @@
 - [Chetanand](https://github.com/chetanandmeher)
 - [JoeArias1121](https://github.com/JoeArias1121)
 - [ATgmu](https://githum.com/ATgmu)
+- [brison-coder](https://github.com/brison-coder)
 - [Saleeq Adnan Syed](https://github.com/CyberCoder-IITM)
 - [Mengyuan Ding](https://github.com/jessy-ding)
 - [6NaCl](https://github.com/6NaCl)

--- a/docs/cli-tool-tutorials/github-cli-tutorial-pt-br.md
+++ b/docs/cli-tool-tutorials/github-cli-tutorial-pt-br.md
@@ -67,7 +67,7 @@ replacing `seu-nome-branch` com o nome do branch que você criou anterioramente.
 - ### Erro de Autenticação
      <pre>remote: Support for password authentication was removed on August 13, 2021. Please use a personal access token instead.
   remote: Por favor veja https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/ para mais informações.
-  fatal: Authentication failed for 'https://github.com/<your-username>/first-contributions.git/'</pre>
+  fatal: Authentication failed for 'https://github.com/&lt;your-username&gt;/first-contributions.git/'</pre>
   Vá para o [Tutorial do GitHub](https://docs.github.com/pt/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account) sobre como gerar e configurar uma chave SSH para sua conta.
 
 </details>


### PR DESCRIPTION
## Description

This PR fixes the display of the authentication error example in the Portuguese (Brazil) GitHub CLI tutorial.

### Changes made

* Replaced `<` with `&lt;`
* Replaced `>` with `&gt;`

in the line:

`fatal: Authentication failed for 'https://github.com/<your-username>/first-contributions.git/'`

This ensures that the placeholder username is displayed correctly instead of being interpreted as HTML/code.

Closes #118516 
