### PR TITLE
Fix angle brackets in Albanian README

### DIFF
--- a/docs/translations/README.sq.md
+++ b/docs/translations/README.sq.md
@@ -99,7 +99,7 @@ Duke zëvendësuar `emri-jot-i-deges-se-re` me emrin e degës që krijove më pa
 - ### Gabim i Autentikimit
      <pre>remote: Support for password authentication was removed on August 13, 2021. Please use a personal access token instead.
   remote: Please see https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/ for more information.
-  fatal: Authentication failed for 'https://github.com/<your-username>/first-contributions.git/'</pre>
+  fatal: Authentication failed for 'https://github.com/&lt;your-username&gt;/first-contributions.git/'</pre>
   Shko te [tutoriali i GitHub](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account) mbi gjenerimin dhe konfigurimin e një çelësi SSH në llogarinë tënde.
 
 </details>


### PR DESCRIPTION
Replaced angle brackets with HTML entities in the Albanian README to ensure the username placeholder is displayed correctly.