### PR TITLE
Fix: Fixed angle brackets in Lithuanian translation README

### DIFF
--- a/docs/translations/README.lt.md
+++ b/docs/translations/README.lt.md
@@ -101,7 +101,7 @@ pakeisdami `<tavo-sakos-vardas>` anskčiau sukurtos šakos (branch) vardu.
 - ### Autentifikacijos klaida
      <pre>remote: Support for password authentication was removed on August 13, 2021. Please use a personal access token instead.
   remote: Please see https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/ for more information.
-  fatal: Authentication failed for 'https://github.com/<your-username>/first-contributions.git/'</pre>
+  fatal: Authentication failed for 'https://github.com/&lt;your-username&gt;/first-contributions.git/'</pre>
   [GitHub vadovas](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account) padės jums sugeneruoti ir sukonfiguruoti SSH raktą savo paskyroje.
 
   Taip pat, galbūt norėsite pabandyti 'git remote -v', skirtą patikrintite savo nuotolinį adresą (remote address).


### PR DESCRIPTION
Fixed the authentication error example in the Lithuanian translation of the README.

Replaced the angle brackets around `your-username` with their HTML entity equivalents (`&lt;` and `&gt;`) so the placeholder is displayed correctly instead of being interpreted as HTML.

Resolves #118491
