### PR TITLE
fix: escape angle brackets in Somali translation

### DIFF
--- a/docs/translations/README.so.md
+++ b/docs/translations/README.so.md
@@ -117,7 +117,7 @@ Adigoo `magaca-laantaada` ku badalaya magaca laanta aad hore u abuurtay.
 - ### Cilad Xaqiijin
      <pre>remote: Support for password authentication was removed on August 13, 2021. Please use a personal access token instead.
   remote: Please see https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/ for more information.
-  fatal: Authentication failed for 'https://github.com/<your-username>/first-contributions.git/'</pre>
+  fatal: Authentication failed for 'https://github.com/&lt;your-username&gt;/first-contributions.git/'</pre>
   Tag [casharrada GitHub](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account) ee ku saabsan abuuritaanka iyo habaynta furaha SSH ee akoonkaaga
 
 </details>


### PR DESCRIPTION
Resolves #118844

Escaped angle brackets in the authentication failed example so the placeholder username renders correctly.