### PR TITLE
remove-harry-potter-git

### DIFF
--- a/.github/workflows/auto-pr-merge.yml
+++ b/.github/workflows/auto-pr-merge.yml
@@ -88,7 +88,6 @@ jobs:
                   'https://media1.giphy.com/media/artj92V8o75VPL7AeQ/giphy.gif',
                   'https://media2.giphy.com/media/IwAZ6dvvvaTtdI8SD5/giphy.gif',
                   'https://media0.giphy.com/media/z8gtBVdZVrH20/giphy.gif',
-                  'https://media2.giphy.com/media/26gN16cJ6gy4LzZSw/giphy.gif',
                   'https://media1.giphy.com/media/LZElUsjl1Bu6c/giphy.gif',
                   'https://media1.giphy.com/media/gHnwTttExPf4nwOWm7/giphy.gif',
                 ]


### PR DESCRIPTION
Title: Remove Harry Potter gif from celebration gifs in auto-merge workflow

Addresses #118229

Description:
This PR removes the Harry Potter-themed gif from the `celebrationGifs` array in `.github/workflows/auto-pr-merge.yml`.

Changes made:
- Removed the single Harry Potter gif entry from the celebration gifs list used when a PR is auto-merged.
- No other changes were made; the rest of the workflow remains untouched.

Testing:
- Verified that the array syntax remains valid after the removal and that no trailing comma issues were introduced.