### PR TITLE
Fix angle brackets in Nepali README

### DIFF
--- a/docs/translations/README.np.md
+++ b/docs/translations/README.np.md
@@ -179,7 +179,7 @@ git push -u origin add-ram-regmi
 - ### Authentication Error
   <pre>remote: पासवर्ड प्रमाणीकरण (authentication) को समर्थन अगस्ट 13, 2021 मा हटाइएको थियो। कृपया यसको सट्टा personal access token प्रयोग गर्नुहोस्।
   remote: थप जानकारीको लागी https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/ हेर्नुहोस्।
-  fatal: 'https://github.com/<your-username>/first-contributions.git/' को लागी प्रमाणीकरण असफल भयो।</pre>
+  fatal: 'https://github.com/&lt;your-username&gt;/first-contributions.git/' को लागी प्रमाणीकरण असफल भयो।</pre>
     [GitHub's tutorial](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account) मा गएर आफ्नो account को लागी SSH key generate र configure गर्नुहोस्।
 </details>
 


### PR DESCRIPTION
Fixes #118495

Replaced < and > with &lt; and &gt; in the authentication error message
in the Nepali translation (README.np.md).