### PR TITLE
Fix angle brackets in Dutch README translation

### DIFF
--- a/docs/translations/README.nl.md
+++ b/docs/translations/README.nl.md
@@ -99,7 +99,7 @@ Vervang `je-nieuwe-branch-naam` met de naam van de branch die je eerder hebt aan
 - ### Authentication Error
      <pre>remote: Support for password authentication was removed on August 13, 2021. Please use a personal access token instead.
   remote: Please see https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/ for more information.
-  fatal: Authentication failed for 'https://github.com/<your-username>/first-contributions.git/'</pre>
+  fatal: Authentication failed for 'https://github.com/&lt;your-username&gt;/first-contributions.git/'</pre>
   Ga naar [GitHub's tutorial](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account) voor het genereren en configureren van een SSH-sleutel in je account.
 
 </details>


### PR DESCRIPTION
### Summary

Replaced the angle brackets in the authentication error example in the Dutch README translation.

### Changes
- Replaced <your-username> with &lt;your-username&gt;
- Ensures the placeholder displays correctly.

Resolves #118493