### PR TITLE
Replaced angle brackets in the Filipino translation of README  #118485

### DIFF
--- a/docs/translations/README.fil.md
+++ b/docs/translations/README.fil.md
@@ -98,7 +98,7 @@ Ang `pangalan-ng-branch` ay pangalan ng branch na ginawa mo kanina.
 - ### Error sa Pagpapatunay
     <pre>remote: Support for password authentication was removed on August 13, 2021. Please use a personal access token instead.
     remote: Please see https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/ for more information.
-    fatal: Authentication failed for 'https://github.com//first-contributions.git/'</pre>
+   fatal: Authentication failed for 'https://github.com/&lt;your-username&gt;/first-contributions.git/'</pre>
   Pumunta sa [tutorial ng GitHub](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account) sa paggawa at pag-configure ng SSH key sa iyong account.
 </details>
 


### PR DESCRIPTION
## Description

Replaced the angle brackets in the Filipino README translation error message with HTML entities (`&lt;` and `&gt;`) so that `<your-username>` is displayed correctly in the rendered documentation.

Resolves #118485
