### PR TITLE
Fix unbalanced quote in commit example (CLI tutorial)

### DIFF
--- a/docs/cli-tool-tutorials/github-cli-tutorial.md
+++ b/docs/cli-tool-tutorials/github-cli-tutorial.md
@@ -55,7 +55,7 @@ Add those changes to the branch you just created using the `git add` command:
 `git add Contributors.md`
 
 Now commit those changes using the `git commit` command:
-`git commit -m "Add your-name to Contributors list`
+`git commit -m "Add your-name to Contributors list"`
 replacing `your-name` with your name.
 
 # Push changes to github

--- a/docs/cli-tool-tutorials/github-cli-tutorial.md
+++ b/docs/cli-tool-tutorials/github-cli-tutorial.md
@@ -58,7 +58,7 @@ Now commit those changes using the `git commit` command:
 `git commit -m "Add your-name to Contributors list"`
 replacing `your-name` with your name.
 
-# Push changes to github
+# Push changes to GitHub
 
 Push your changes using the command `git push`:
 


### PR DESCRIPTION
The example commit command in the GitHub CLI tutorial was missing its closing double-quote:

```
git commit -m "Add your-name to Contributors list
```

A reader copying it verbatim ends up with a hanging shell waiting for the closing quote. This adds the missing `"`.