### PR TITLE
Remove celebration GIF from auto-merge workflow

### DIFF
--- a/.github/workflows/auto-pr-merge.yml
+++ b/.github/workflows/auto-pr-merge.yml
@@ -87,7 +87,6 @@ jobs:
                   'https://c.tenor.com/JHndvQVcsBUAAAAC/fern-pat-fern-good-job.gif',
                   'https://media1.giphy.com/media/artj92V8o75VPL7AeQ/giphy.gif',
                   'https://media2.giphy.com/media/IwAZ6dvvvaTtdI8SD5/giphy.gif',
-                  'https://media2.giphy.com/media/26gN16cJ6gy4LzZSw/giphy.gif',
                   'https://media0.giphy.com/media/z8gtBVdZVrH20/giphy.gif',
                   'https://media1.giphy.com/media/LZElUsjl1Bu6c/giphy.gif',
                   'https://media1.giphy.com/media/gHnwTttExPf4nwOWm7/giphy.gif',


### PR DESCRIPTION
Addresses #118229

Removed one GIF from celebration list as requested to align with updated community guidelines.