### PR TITLE
Fix HTML tag formatting in Polish git CLI tutorial

### DIFF
--- a/docs/cli-tool-tutorials/git-cli-tutorial-PL.md
+++ b/docs/cli-tool-tutorials/git-cli-tutorial-PL.md
@@ -56,7 +56,7 @@ git switch -c add-john-doe
 Teraz możesz otworzyć plik `Contributors.md` w edytorze tekstu i dodać do niego swoje imię. Wstaw swoje imię w dowolnym miejscu między początkiem a końcem, a następnie zapisz plik.
 
 W katalogu projektu wykonaj `git status`, a zobaczysz zmiany.
-\<img align="right" width="450" src="[https://firstcontributions.github.io/assets/Readme/git-status.png](https://firstcontributions.github.io/assets/Readme/git-status.png)" alt="git status" /\>
+<img align="right" width="450" src="[https://firstcontributions.github.io/assets/Readme/git-status.png](https://firstcontributions.github.io/assets/Readme/git-status.png)" alt="git status" />
 
 Dodaj te zmiany do właśnie utworzonej gałęzi za pomocą polecenia `git add`:
 `git add Contributors.md`
@@ -78,14 +78,17 @@ git push origin -u your-branch-name
 zastępując `your-branch-name` nazwą gałęzi, którą utworzyłeś wcześniej.
 
 <details>
-<summary> <strong>Jeśli podczas wypychania wystąpią błędy, kliknij tutaj:</strong> </summary>
+<summary><strong>Jeśli podczas wypychania wystąpią błędy, kliknij tutaj:</strong></summary>
 
-  - ### Authentication Error
+### Authentication Error
 
-     <pre>remote: Support for password authentication was removed on August 13, 2021. Please use a personal access token instead.
-  remote: Please see [https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/](https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/) for more information.
-  fatal: Authentication failed for '[https://github.com/](https://github.com/)<your-username>/first-contributions.git/'</pre>
-  Przejdź do [tutoriala GitHub](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account) dotyczącego generowania i konfigurowania klucza SSH na swoim koncie.
+  <pre>
+    remote: Support for password authentication was removed on August 13, 2021. Please use a personal access token instead.
+    remote: Please see [https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/](https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/) for more information.
+    fatal: Authentication failed for '[https://github.com/](https://github.com/)<your-username>/first-contributions.git/'
+  </pre>
+
+  Przejdź do [tutoriala GitHub](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account) dotyczącego generowania i konfigurowania klucza SSH na swoim koncie.
 
 </details>
 

--- a/docs/cli-tool-tutorials/git-cli-tutorial-PL.md
+++ b/docs/cli-tool-tutorials/git-cli-tutorial-PL.md
@@ -77,17 +77,18 @@ git push origin -u your-branch-name
 
 zastępując `your-branch-name` nazwą gałęzi, którą utworzyłeś wcześniej.
 
-\<details\>
-\<summary\> \<strong\>Jeśli podczas wypychania wystąpią błędy, kliknij tutaj:\</strong\> \</summary\>
+<details>
+<summary> <strong>Jeśli podczas wypychania wystąpią błędy, kliknij tutaj:</strong> </summary>
 
   - ### Authentication Error
 
-     \<pre\>remote: Support for password authentication was removed on August 13, 2021. Please use a personal access token instead.
-  remote: Please see [https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/](https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/) for more information.
-  fatal: Authentication failed for '[https://github.com/](https://github.com/)\<your-username\>/first-contributions.git/'\</pre\>
-  Przejdź do [tutoriala GitHub](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account) dotyczącego generowania i konfigurowania klucza SSH na swoim koncie.
+     <pre>remote: Support for password authentication was removed on August 13, 2021. Please use a personal access token instead.
+  remote: Please see [https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/](https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/) for more information.
+  fatal: Authentication failed for '[https://github.com/](https://github.com/)<your-username>/first-contributions.git/'</pre>
 
-\</details\>
+  Przejdź do [tutoriala GitHub](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account) dotyczącego generowania i konfigurowania klucza SSH na swoim koncie.
+
+</details>
 
 -----
 

--- a/docs/cli-tool-tutorials/git-cli-tutorial-PL.md
+++ b/docs/cli-tool-tutorials/git-cli-tutorial-PL.md
@@ -82,11 +82,10 @@ zastępując `your-branch-name` nazwą gałęzi, którą utworzyłeś wcześniej
 
   - ### Authentication Error
 
-     <pre>remote: Support for password authentication was removed on August 13, 2021. Please use a personal access token instead.
-  remote: Please see [https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/](https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/) for more information.
-  fatal: Authentication failed for '[https://github.com/](https://github.com/)<your-username>/first-contributions.git/'</pre>
-
-  Przejdź do [tutoriala GitHub](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account) dotyczącego generowania i konfigurowania klucza SSH na swoim koncie.
+     <pre>remote: Support for password authentication was removed on August 13, 2021. Please use a personal access token instead.
+  remote: Please see [https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/](https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/) for more information.
+  fatal: Authentication failed for '[https://github.com/](https://github.com/)<your-username>/first-contributions.git/'</pre>
+  Przejdź do [tutoriala GitHub](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account) dotyczącego generowania i konfigurowania klucza SSH na swoim koncie.
 
 </details>
 


### PR DESCRIPTION
Fixes the formatting issue in the Polish CLI tutorial by removing the unnecessary backslashes before HTML tags in the collapsible section.

Resolves #118479