### PR TITLE
Fix angle brackets in Indonesian README

### DIFF
--- a/docs/translations/README.id.md
+++ b/docs/translations/README.id.md
@@ -113,7 +113,7 @@ ganti bagian `<tambahkan-nama-cabang-baru>` dengan nama cabang yang sebelumnya A
        <pre>remote: Support for password authentication was removed on August 13, 2021. Please use a personal access token instead.
 
   remote: Please see https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/ for more information.
-  fatal: Authentication failed for 'https://github.com/<your-username>/first-contributions.git/'</pre>
+  fatal: Authentication failed for 'https://github.com/&lt;your-username&gt;/first-contributions.git/'</pre>
   Buka [tutorial GitHub](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account) untuk menghasilkan dan mengkonfigurasi sebuah kunci SSH ke akun Anda.
 
   Jika kelihatannya seperti ini:


### PR DESCRIPTION
This PR resolves the issue where the placeholder text `<your-username>` in the authentication error section of the Indonesian README was hidden.

Similar to the issue fixed in the Korean translation (#118489), the raw angle brackets `<` and `>` in `docs/translations/README.id.md` were being incorrectly parsed as HTML/XML tags, making the placeholder invisible. Replacing them with `&lt;` and `&gt;` ensures the text is rendered correctly.

Resolves #118489
