### PR TITLE
fix(docs): correct hyperlink formatting in Polish git CLI tutorial

### DIFF
--- a/docs/cli-tool-tutorials/git-cli-tutorial-PL.md
+++ b/docs/cli-tool-tutorials/git-cli-tutorial-PL.md
@@ -56,7 +56,7 @@ git switch -c add-john-doe
 Teraz możesz otworzyć plik `Contributors.md` w edytorze tekstu i dodać do niego swoje imię. Wstaw swoje imię w dowolnym miejscu między początkiem a końcem, a następnie zapisz plik.
 
 W katalogu projektu wykonaj `git status`, a zobaczysz zmiany.
-<img align="right" width="450" src="[https://firstcontributions.github.io/assets/Readme/git-status.png](https://firstcontributions.github.io/assets/Readme/git-status.png)" alt="git status" />
+<img align="right" width="450" src="https://firstcontributions.github.io/assets/Readme/git-status.png" alt="git status" />
 
 Dodaj te zmiany do właśnie utworzonej gałęzi za pomocą polecenia `git add`:
 `git add Contributors.md`
@@ -85,7 +85,7 @@ zastępując `your-branch-name` nazwą gałęzi, którą utworzyłeś wcześniej
   <pre>
     remote: Support for password authentication was removed on August 13, 2021. Please use a personal access token instead.
     remote: Please see [https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/](https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/) for more information.
-    fatal: Authentication failed for '[https://github.com/](https://github.com/)<your-username>/first-contributions.git/'
+    fatal: Authentication failed for 'https://github.com/<your-username>/first-contributions.git/'
   </pre>
 
   Przejdź do [tutoriala GitHub](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account) dotyczącego generowania i konfigurowania klucza SSH na swoim koncie.


### PR DESCRIPTION
Resolves #119729
Fixed incorrect hyperlink formatting in the Polish Git CLI tutorial.
Changes:
1. Removed invalid hyperlink syntax from the image URL.
2. Removed invalid hyperlink syntax from the repository URL example.