### PR TITLE
docs: fix angle brackets in Odia README

### DIFF
--- a/docs/translations/README.od.md
+++ b/docs/translations/README.od.md
@@ -99,7 +99,7 @@ git push -u <ଉତ୍ପତ୍ତି ତୁମର ଶାଖା-ନାମ>
 - ### ପ୍ରାମାଣିକିକରଣ ତ୍ରୁଟି |
   <pre>ସୁଦୂର: ପାସୱାର୍ଡ ପ୍ରାମାଣିକିକରଣ ପାଇଁ ସମର୍ଥନ ଅଗଷ୍ଟ 13, 2021 ରେ ଅପସାରିତ ହୋଇଥିଲା। ଦୟାକରି ଏହା ବଦଳରେ ଏକ ବ୍ୟକ୍ତିଗତ ପ୍ରବେଶ ଟୋକେନ୍ ବ୍ୟବହାର କରନ୍ତୁ |
   ସୁଦୂର: ଅଧିକ ସୂଚନା ପାଇଁ ଦୟାକରି https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/ ଦେଖନ୍ତୁ |
-  ସାଂଘାତିକ: 'https://github.com/ &lt;your-username&gt; /first-contributions.git/' ପାଇଁ ପ୍ରାମାଣିକିକରଣ ବିଫଳ ହେଲା |
+  ସାଂଘାତିକ: 'https://github.com/&lt;your-username&gt;/first-contributions.git/' ପାଇଁ ପ୍ରାମାଣିକିକରଣ ବିଫଳ ହେଲା |
   </pre>
   [GitHub ର ଟ୍ୟୁଟୋରିଆଲ୍] କୁ ଯାଆନ୍ତୁ (https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account) ଆପଣଙ୍କ ଖାତାକୁ ଏକ SSH କି ସୃଷ୍ଟି ଏବଂ ବିନ୍ୟାସ କରିବା |
 

--- a/docs/translations/README.od.md
+++ b/docs/translations/README.od.md
@@ -99,7 +99,7 @@ git push -u <ଉତ୍ପତ୍ତି ତୁମର ଶାଖା-ନାମ>
 - ### ପ୍ରାମାଣିକିକରଣ ତ୍ରୁଟି |
   <pre>ସୁଦୂର: ପାସୱାର୍ଡ ପ୍ରାମାଣିକିକରଣ ପାଇଁ ସମର୍ଥନ ଅଗଷ୍ଟ 13, 2021 ରେ ଅପସାରିତ ହୋଇଥିଲା। ଦୟାକରି ଏହା ବଦଳରେ ଏକ ବ୍ୟକ୍ତିଗତ ପ୍ରବେଶ ଟୋକେନ୍ ବ୍ୟବହାର କରନ୍ତୁ |
   ସୁଦୂର: ଅଧିକ ସୂଚନା ପାଇଁ ଦୟାକରି https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/ ଦେଖନ୍ତୁ |
-  ସାଂଘାତିକ: 'https://github.com/ <your-username> /first-contributions.git/' ପାଇଁ ପ୍ରାମାଣିକିକରଣ ବିଫଳ ହେଲା |
+  ସାଂଘାତିକ: 'https://github.com/ &lt;your-username&gt; /first-contributions.git/' ପାଇଁ ପ୍ରାମାଣିକିକରଣ ବିଫଳ ହେଲା |
   </pre>
   [GitHub ର ଟ୍ୟୁଟୋରିଆଲ୍] କୁ ଯାଆନ୍ତୁ (https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account) ଆପଣଙ୍କ ଖାତାକୁ ଏକ SSH କି ସୃଷ୍ଟି ଏବଂ ବିନ୍ୟାସ କରିବା |
 


### PR DESCRIPTION
Fixes ##119734

Replaced < and > with &lt; and &gt; in the authentication error message
in the Odia translation (README.od.md).