### PR TITLE
Fix rendering of angle brackets in README.ln.md

### DIFF
--- a/docs/translations/README.ln.md
+++ b/docs/translations/README.ln.md
@@ -111,7 +111,7 @@ longola makomi oyo `<kombo-ya-branche-na-yo>` mpe tia kombo ya branche oyo osili
 - ### Erreur ya authentification
   <pre>remote: Support for password authentication was removed on August 13, 2021. Please use a personal access token instead. 
   remote: Please see https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/ for more information. 
-  fatal: Authentication failed for 'https://github.com/<kombo-na-yo-ya-utilisateur>/first-contributions.git/'</pre>
+  fatal: Authentication failed for 'https://github.com/&lt;kombo-na-yo-ya-utilisateur&gt;/first-contributions.git/'</pre>
   Landa tutoriel ya GitHub mpo na kosala mpe ko configurer clé SSH na compte na yo.
 
 Okoki mpe kosala `git remote -v` mpo na kotala adresse na yo ya mosika.


### PR DESCRIPTION
This PR escapes the angle brackets in the Lingala translation file (`docs/translations/README.ln.md`) to fix the rendering of the authentication error code, preventing `<kombo-na-yo-ya-utilisateur>` from being hidden.

Resolves #119733

Before submitting this pull request, check the changes to see it's only the changes you made intentionally
If there are changes to other lines you didn't make deliberately, it's possible that your IDE made the changes with a utility like prettier.
Next time, make sure that you only add your changes by using `git add -p` and rather than `git add Contributors.md`

If you're doing something in the checklist below, put an `x` inside `[ ]` so that `- [ ]` becomes `- [x]`

- [x] I had fun going through this tutorial (ノ^o^)ノ and learned on the way ٩(＾◡＾)۶
- [ ] There are some things I'd like to improve in this tutorial. I have written them below.
- [ ] There were steps where I had errors while following this tutorial. I have written them below.