### PR TITLE
fix: replace angle brackets with HTML entities in Arabic CLI tutorial

### DIFF
--- a/docs/cli-tool-tutorials/github-cli-tutorials-arabic.md
+++ b/docs/cli-tool-tutorials/github-cli-tutorials-arabic.md
@@ -89,7 +89,7 @@ git push origin -u اسم-الفرع
 <pre>
 remote: Support for password authentication was removed on August 13, 2021. Please use a personal access token instead.
 remote: Please see https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/ for more information.
-fatal: Authentication failed for 'https://github.com/<your-username>/first-contributions.git/'
+fatal: Authentication failed for 'https://github.com/&lt;your-username&gt;/first-contributions.git/'
 </pre>
 
 لحل المشكلة، اتبع [دليل GitHub](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account) الرسمي لإعداد مفتاح SSH وربطه بحسابك.


### PR DESCRIPTION
Closes #119737

Replace angle brackets with HTML entities in the Arabic translation of the GitHub CLI tutorial, matching the format used in the English version.