### PR TITLE
Fix formatting in Kyrgyz README - add line breaks to error code block

### DIFF
--- a/docs/translations/README.ky.md
+++ b/docs/translations/README.ky.md
@@ -83,7 +83,9 @@ git push -u origin your-branch-name
 
 - ### Аутентификация катасы (authentication error)
 
-     <pre>remote: Support for password authentication was removed on August 13, 2021. Please use a personal access token instead.   remote: Please see https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/ for more information.   fatal: Authentication failed for 'https://github.com/&lt;your-username&gt;/first-contributions.git/'</pre>   [GitHub'дын окуу материалына](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account) өтүп, аккаунтуңузга SSH ачкычын түзүү жана конфигурациялоо боюнча окуңуз.
+     <pre>remote: Support for password authentication was removed on August 13, 2021. Please use a personal access token instead.
+  remote: Please see https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/ for more information.
+  fatal: Authentication failed for 'https://github.com/&lt;your-username&gt;/first-contributions.git/'</pre>   [GitHub'дын окуу материалына](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account) өтүп, аккаунтуңузга SSH ачкычын түзүү жана конфигурациялоо боюнча окуңуз.
   Ошондой эле, алыскы дарегиңизди текшерүү үчүн 'git remote -v' командасын аткаргыңыз келиши мүмкүн.      Эгер ал ушундай көрүнсө:   <pre>origin https://github.com/your-username/your_repo.git (fetch)   origin https://github.com/your-username/your_repo.git (push)</pre>      Аны төмөнкү команда менен өзгөртүңүз:   ```bash   git remote set-url origin git@github.com:your-username/your_repo.git   ```   Антпесе, сизге дагы деле колдонуучу аты жана сырсөз суралып, аутентификация катасы келе берет.
 </details>
 

--- a/docs/translations/README.ky.md
+++ b/docs/translations/README.ky.md
@@ -83,9 +83,10 @@ git push -u origin your-branch-name
 
 - ### Аутентификация катасы (authentication error)
 
-     <pre>remote: Support for password authentication was removed on August 13, 2021. Please use a personal access token instead.
+  <pre>remote: Support for password authentication was removed on August 13, 2021. Please use a personal access token instead.
   remote: Please see https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/ for more information.
-  fatal: Authentication failed for 'https://github.com/&lt;your-username&gt;/first-contributions.git/'</pre>   [GitHub'дын окуу материалына](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account) өтүп, аккаунтуңузга SSH ачкычын түзүү жана конфигурациялоо боюнча окуңуз.
+  fatal: Authentication failed for 'https://github.com/&lt;your-username&gt;/first-contributions.git/'</pre>
+  [GitHub'дын окуу материалына](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account) өтүп, аккаунтуңузга SSH ачкычын түзүү жана конфигурациялоо боюнча окуңуз.
   Ошондой эле, алыскы дарегиңизди текшерүү үчүн 'git remote -v' командасын аткаргыңыз келиши мүмкүн.      Эгер ал ушундай көрүнсө:   <pre>origin https://github.com/your-username/your_repo.git (fetch)   origin https://github.com/your-username/your_repo.git (push)</pre>      Аны төмөнкү команда менен өзгөртүңүз:   ```bash   git remote set-url origin git@github.com:your-username/your_repo.git   ```   Антпесе, сизге дагы деле колдонуучу аты жана сырсөз суралып, аутентификация катасы келе берет.
 </details>
 


### PR DESCRIPTION
## Summary
Fixed the formatting in the Kyrgyz translation of README (docs/translations/README.ky.md).

## Problem
The <pre> block in the authentication error section had all three error code lines on the same line (separated by spaces), instead of proper line breaks. This caused the error codes to display incorrectly.

## Fix
Added proper line breaks inside the <pre> tag so each error message appears on its own line.

Resolves #118472