### PR TITLE
Fix angle brackets in polish CLI tutorials

### DIFF
--- a/docs/cli-tool-tutorials/git-cli-tutorial-PL.md
+++ b/docs/cli-tool-tutorials/git-cli-tutorial-PL.md
@@ -85,7 +85,7 @@ zastępując `your-branch-name` nazwą gałęzi, którą utworzyłeś wcześniej
   <pre>
     remote: Support for password authentication was removed on August 13, 2021. Please use a personal access token instead.
     remote: Please see [https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/](https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/) for more information.
-    fatal: Authentication failed for 'https://github.com/<your-username>/first-contributions.git/'
+    fatal: Authentication failed for 'https://github.com/&lt;your-username&gt;/first-contributions.git/'
   </pre>
 
   Przejdź do [tutoriala GitHub](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account) dotyczącego generowania i konfigurowania klucza SSH na swoim koncie.


### PR DESCRIPTION
## Summary

This PR fixes issue #120069 by replacing the angle brackets (`<` and `>`) with their HTML entities (`&lt;` and `&gt;`) in the Polish CLI tutorial. This ensures `<your-username>` is displayed correctly instead of being interpreted as an HTML tag.

Resolves #120069
Before submitting this pull request, check the changes to see it's only the changes you made intentionally
If there are changes to other lines you didn't make deliberately, it's possible that your IDE made the changes with a utility like prettier.
Next time, make sure that you only add your changes by using `git add -p` and rather than `git add Contributors.md`

If you're doing something in the checklist below, put an `x` inside `[ ]` so that `- [ ]` becomes `- [x]`

- [ ] I had fun going through this tutorial (ノ^o^)ノ and learned on the way ٩(＾◡＾)۶
- [ ] There are some things I'd like to improve in this tutorial. I have written them below.
- [ ] There were steps where I had errors while following this tutorial. I have written them below.