### PR TITLE
fix(docs): escape angle brackets in Polish CLI tutorial

### DIFF
--- a/docs/cli-tool-tutorials/git-cli-tutorial-PL.md
+++ b/docs/cli-tool-tutorials/git-cli-tutorial-PL.md
@@ -85,7 +85,7 @@ zastępując `your-branch-name` nazwą gałęzi, którą utworzyłeś wcześniej
   <pre>
     remote: Support for password authentication was removed on August 13, 2021. Please use a personal access token instead.
     remote: Please see [https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/](https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/) for more information.
-    fatal: Authentication failed for 'https://github.com/<your-username>/first-contributions.git/'
+    fatal: Authentication failed for 'https://github.com/&lt;your-username&gt;/first-contributions.git/'
   </pre>
 
   Przejdź do [tutoriala GitHub](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account) dotyczącego generowania i konfigurowania klucza SSH na swoim koncie.


### PR DESCRIPTION
## Summary
This PR fixes the rendering of the `<your-username>` placeholder in the Polish Git CLI tutorial.
## Changes

- Replaced `<` with `&lt;`
- Replaced `>` with `&gt;` in the authentication error example so the placeholder displays correctly.

Resolves #120069