### PR TITLE
Add Markus Baumann to Contributors list

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -674,6 +674,7 @@
 - [Domenico Vecchio](https://github.com/domenico-vecchio)
 - [Dominic](https://github.com/mozz37)
 - [DonnieJ](https://github.com/jdmade)
+- [Markus Baumann](https://github.com/eybmits)
 
 Aakash Gupta
 


### PR DESCRIPTION
Add Markus Baumann to the Contributors list following the project tutorial.

Validation: reviewed the single-line Contributors.md diff.