### PR TITLE
Fix angle brackets in German CLI tutorial

### DIFF
--- a/docs/cli-tool-tutorials/github-cli-tutorial-german.md
+++ b/docs/cli-tool-tutorials/github-cli-tutorial-german.md
@@ -71,7 +71,7 @@ Ersetzen Sie `your-branch-name` durch den Namen des Branches, den Sie zuvor erst
 - ### Authentifizierungsfehler
   <pre>Remote: Die Unterstützung für Passwortauthentifizierung wurde am 13. August 2021 entfernt. Verwenden Sie stattdessen bitte ein Personal Access Token.
   Remote: Weitere Informationen finden Sie unter https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/.
-  Fatal: Authentifizierung für 'https://github.com//first-contrib.git/' fehlgeschlagen</pre>
+  Fatal: Authentifizierung für 'https://github.com/&lt;your-username&gt;/first-contrib.git/' fehlgeschlagen</pre>
   [GitHub-Anleitung zum Erstellen und Konfigurieren eines SSH-Schlüssels für Ihr Konto](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account).
 
 # Reichen Sie Ihre Änderungen zur Überprüfung ein


### PR DESCRIPTION
Replaced < and > with HTML entities (&lt; and &gt;) in the authentication failed example so the username placeholder is displayed correctly.

Resolves #120261