### PR TITLE
Fix additional material links in GUI tutorials

### DIFF
--- a/docs/gui-tool-tutorials/github-desktop-old-version-tutorial.md
+++ b/docs/gui-tool-tutorials/github-desktop-old-version-tutorial.md
@@ -98,7 +98,7 @@ Congrats!  You just completed the standard _fork -> clone -> edit -> PR_ workflo
 Celebrate your contribution and share it with your friends and followers by going to [web app](https://firstcontributions.github.io#social-share).
 
 
-### [Additional material](../additional-material/git_workflow_senarios/additional-material.md)
+### [Additional material](../additional-material/git_workflow_scenarios/additional-material.md)
 
 
 ## Tutorials Using Other Tools

--- a/docs/gui-tool-tutorials/sublime-merge-tutorial.hi.md
+++ b/docs/gui-tool-tutorials/sublime-merge-tutorial.hi.md
@@ -103,7 +103,7 @@ GitHub पर अपनी रिपॉज़िटरी में जाएँ
 
 अपने योगदान का जश्न मनाएँ और अपने दोस्तों व फ़ॉलोअर्स के साथ शेयर करें: [web app](https://firstcontributions.github.io#social-share)।
 
-### [अतिरिक्त सामग्री](../additional-material/git_workflow_senarios/additional-material.md)
+### [अतिरिक्त सामग्री](../additional-material/git_workflow_scenarios/additional-material.md)
 
 ## अन्य टूल्स के साथ ट्यूटोरियल्स
 [मुख्य पृष्ठ पर वापस जाएँ](https://github.com/firstcontributions/first-contributions#tutorials-using-other-tools)

--- a/docs/gui-tool-tutorials/sublime-merge-tutorial.md
+++ b/docs/gui-tool-tutorials/sublime-merge-tutorial.md
@@ -110,7 +110,7 @@ Congrats!  You have just completed the standard _fork -> clone -> edit -> PR_ wo
 
 Celebrate your contribution and share it with your friends and followers by going to [web app](https://firstcontributions.github.io#social-share).
 
-### [Additional material](../additional-material/git_workflow_senarios/additional-material.md)
+### [Additional material](../additional-material/git_workflow_scenarios/additional-material.md)
 
 
 ## Tutorials Using Other Tools

--- a/docs/gui-tool-tutorials/translations/Greek/github-desktop-old-version-tutorial.gr.md
+++ b/docs/gui-tool-tutorials/translations/Greek/github-desktop-old-version-tutorial.gr.md
@@ -71,7 +71,7 @@
 Γιορτάστε τη συνεισφορά σας και μοιραστείτε τη με τους φίλους σας και τους ακόλουθούς σας πηγαίνοντας στην [ιστοσελίδα εφαρμογής](https://firstcontributions.github.io#social-share).
 
 
-### [Πρόσθετο υλικό](../additional-material/git_workflow_senarios/additional-material.md)
+### [Πρόσθετο υλικό](../../../additional-material/git_workflow_scenarios/additional-material.md)
 
 ## Οδηγίες Χρήσης Άλλων Εργαλείων
 

--- a/docs/gui-tool-tutorials/translations/Greek/sublime-merge-tutorial.gr.md
+++ b/docs/gui-tool-tutorials/translations/Greek/sublime-merge-tutorial.gr.md
@@ -110,7 +110,7 @@
 Γιορτάστε τη συνεισφορά σας και μοιραστείτε τη με τους φίλους και τους ακόλουθούς σας, πηγαίνοντας στην [ιστοσελίδα εφαρμογής](https://firstcontributions.github.io#social-share).
 
 
-### [Επιπλέον υλικό](../additional-material/git_workflow_senarios/additional-material.md)
+### [Επιπλέον υλικό](../../../additional-material/git_workflow_scenarios/additional-material.md)
 
 ## Εκπαιδευτικό υλικό για Άλλα Εργαλεία
 [Επιστροφή στην κύρια σελίδα](https://github.com/firstcontributions/first-contributions#tutorials-using-other-tools)

--- a/docs/gui-tool-tutorials/translations/Hindi/sublime-merge-tutorial.hi.md
+++ b/docs/gui-tool-tutorials/translations/Hindi/sublime-merge-tutorial.hi.md
@@ -111,7 +111,7 @@ Branches पर राइट-क्लिक करें -> नई ब्रा
 
 अगर आपको मदद चाहिए या कोई सवाल है तो आप हमारी स्लैक टीम में जॉइन कर सकते हैं। [स्लैक टीम में जॉइन करें](https://join.slack.com/t/firstcontributors/shared_invite/zt-1hg51qkgm-Xc7HxhsiPYNN3ofX2_I8FA)।
 
-### [अतिरिक्त सामग्री](../additional-material/git_workflow_senarios/additional-material.md)
+### [अतिरिक्त सामग्री](../../../additional-material/git_workflow_scenarios/additional-material.md)
 
 ## अन्य टूल्स के लिए ट्यूटोरियल
 [मुख्य पेज पर वापस जाएं](https://github.com/firstcontributions/first-contributions#tutorials-using-other-tools)

--- a/docs/gui-tool-tutorials/translations/Persian/sublime-merge-tutorial-fa.md
+++ b/docs/gui-tool-tutorials/translations/Persian/sublime-merge-tutorial-fa.md
@@ -110,7 +110,7 @@ URL مخزن را در Sublime Merge وارد کنید، یک نام مخزن ب
 
 مشارکت خود را جشن بگیرید و با رفتن به [وب اپلیکیشن](https://firstcontributions.github.io#social-share) آن را با دوستان و دنبال‌کنندگان خود به اشتراک بگذارید.
 
-### [مطالب اضافی](../additional-material/git_workflow_senarios/additional-material.md)
+### [مطالب اضافی](../../../additional-material/git_workflow_scenarios/additional-material.md)
 
 
 ## آموزش‌ها با استفاده از ابزارهای دیگر

--- a/docs/gui-tool-tutorials/translations/Portuguese/github-desktop-tutorial.pt_br.md
+++ b/docs/gui-tool-tutorials/translations/Portuguese/github-desktop-tutorial.pt_br.md
@@ -111,7 +111,7 @@ Comemore sua contribuição e compartilhe com seus amigos e seguidores acessando
 
 Você pode entrar na nossa equipe no Slack caso precise de alguma ajuda ou tenha alguma dúvida. [Entre no Slack](https://join.slack.com/t/firstcontributors/shared_invite/zt-1hg51qkgm-Xc7HxhsiPYNN3ofX2_I8FA).
 
-### [Material adicional](../additional-material/git_workflow_senarios/additional-material.md)
+### [Material adicional](../../../additional-material/git_workflow_scenarios/additional-material.md)
 
 ## Tutoriais usando outras ferramentas
 

--- a/docs/gui-tool-tutorials/translations/github-desktop-tutorial.pt_br.md
+++ b/docs/gui-tool-tutorials/translations/github-desktop-tutorial.pt_br.md
@@ -111,7 +111,7 @@ Comemore sua contribuição e compartilhe com seus amigos e seguidores acessando
 
 Você pode entrar na nossa equipe no Slack caso precise de alguma ajuda ou tenha alguma dúvida. [Entre no Slack](https://join.slack.com/t/firstcontributors/shared_invite/zt-1hg51qkgm-Xc7HxhsiPYNN3ofX2_I8FA).
 
-### [Material adicional](../additional-material/git_workflow_senarios/additional-material.md)
+### [Material adicional](../../additional-material/git_workflow_scenarios/additional-material.md)
 
 ## Tutoriais usando outras ferramentas
 


### PR DESCRIPTION
## Summary
- Fix misspelled `git_workflow_senarios` paths in GUI tutorial additional-material links
- Correct relative paths for affected translated tutorials so the links resolve from their current directories

## Validation
- Ran a focused local Markdown link check for the changed additional-material links
- Ran `git diff --check`