### PR TITLE
Add Gestão Saude Business to Contributors list

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -2347,4 +2347,5 @@ Aakash Gupta
 - [coolysh0318-art](https://github.com/coolysh0318-art)
 
 - [Ahmed Chmourk (Data Science & AI)](https://github.com/ahmedchmourk)
+- [Gestão Saude Business](https://github.com/gestaosaudebusiness-tech)
 


### PR DESCRIPTION
## Summary
- Adds my name and GitHub profile link to Contributors.md, following the repo's contribution guide.

This is my first pull request, made as part of learning the GitHub contribution workflow.