### PR TITLE
fix: update Norwegian translation with language flags and fix broken links

### DIFF
--- a/docs/translations/README.no.md
+++ b/docs/translations/README.no.md
@@ -2,92 +2,6 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 [![Open Source Helpers](https://www.codetriage.com/roshanjossey/first-contributions/badges/users.svg)](https://www.codetriage.com/roshanjossey/first-contributions)
 
-#### _Les dette på [andre språk](Translations.md)._
-<kbd>[<img title="Shqip" alt="Shqip" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/al.svg" width="22">](README.sq.md)</kbd>
-<kbd>[<img title="Armenian" alt="Armenian" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/am.svg" width="22">](README.arm.md)</kbd>
-<kbd>[<img title="Uzbek" alt="Uzbek language" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/uz.svg" width="22">](README.uz.md)</kbd>
-<kbd>[<img title="Azərbaycan dili" alt="Azərbaycan dili" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/az.svg" width="22">](README.aze.md)</kbd>
-<kbd>[<img title="বাংলা" alt="বাংলা" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/bd.svg" width="22">](README.bn.md)</kbd>
-<kbd>[<img title="Bulgarian" alt="Bulgarian" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/bg.svg" width="22">](README.bg.md)</kbd>
-<kbd>[<img title="Português (Brasil)" alt="Português (Brasil)" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/br.svg" width="22">](README.pt_br.md)</kbd>
-<kbd>[<img title="Català" alt="Català" src="https://firstcontributions.github.io/assets/Readme/catalan1.png" width="22">](README.ca.md)</kbd>
-<kbd>[<img title="中文 (Simplified)" alt="中文 (Simplified)" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/cn.svg" width="22">](README.zh-cn.md)</kbd>
-<kbd>[<img title="Czech" alt="Czech" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/cz.svg" width="22">](README.cs.md)</kbd>
-<kbd>[<img title="Deutsch" alt="Deutsch" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/de.svg" width="22">](README.de.md)</kbd>
-<kbd>[<img title="Dansk" alt="Dansk" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/dk.svg" width="22">](README.da.md)</kbd>
-<kbd>[<img title="المصرية" alt="المصرية" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/eg.svg" width="22">](README.eg.md)</kbd>
-<kbd>[<img title="Dezéiriya" alt="Dezéiriya" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/dz.svg" width="22">](README.dz.md)</kbd>
-<kbd>[<img title="Español de España" alt="Español de España" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/es.svg" width="22">](README.es.md)</kbd>
-<kbd>[<img title="Française" alt="Française" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/fr.svg" width="22">](README.fr.md)</kbd>
-<kbd>[<img title="Gaeilge" alt="Gaeilge" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/ie.svg" width="22">](README.ga.md)</kbd>
-<kbd>[<img title="Galego" alt="Galego" src="https://upload.wikimedia.org/wikipedia/commons/6/64/Flag_of_Galicia.svg" width="22">](README.gl.md)</kbd>
-<kbd>[<img title="Ελληνικά" alt="Ελληνικά" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/gr.svg" width="22">](README.gr.md)</kbd>
-<kbd>[<img title="ქართული" alt="ქართული" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/ge.svg" width="22">](README.ge.md)</kbd>
-<kbd>[<img title="Magyar" alt="Magyar" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/hu.svg" width="22">](README.hu.md)</kbd>
-<kbd>[<img title="Bahasa Indonesia" alt="Bahasa Indonesia" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/id.svg" width="22">](README.id.md)</kbd>
-<kbd>[<img title="עִברִית" alt="עִברִית" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/il.svg" width="22">](README.hb.md)</kbd>
-<kbd>[<img title="ગુજરાતી / हिन्दी / मराठी / മലയാളം / ಕನ್ನಡ / తెలుగు / ଓଡିଆ / છત્તીસગઢી / ਪੰਜਾਬੀ" alt="ગુજરાતી / हिन्दी / मराठी / മലയാളം / ಕನ್ನಡ / తెలుగు / ଓଡିଆ / છત્તીસગઢી / ਪੰਜਾਬੀ" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/in.svg" width="22">](Translations.md)</kbd>
-<kbd>[<img title="தமிழ்" alt="தமிழ்" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/lk.svg" width="22">](README.ta.md)</kbd>
-<kbd>[<img title="فارسی" alt="فارسی" src="https://upload.wikimedia.org/wikipedia/commons/b/ba/Flag_of_Iran_before_1979_Revolution.svg" width="22">](README.fa.md)</kbd>
-<kbd>[<img title="Italiano" alt="Italiano" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/it.svg" width="22">](README.it.md)</kbd>
-<kbd>[<img title="日本語" alt="日本語" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/jp.svg" width="22">](README.ja.md)</kbd>
-<kbd>[<img title="සිංහල" alt="සිංහල" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/lk.svg" width="22">](README.si.md)</kbd>
-<kbd>[<img title="한국어" alt="한국어" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/kr.svg" width="22">](README.ko.md)</kbd>
-<kbd>[<img title="Lietuvių kalba" alt="Lietuvių kalba" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/lt.svg" width="22">](README.lt.md)</kbd>
-<kbd>[<img title="Limba Română" alt="Limba Română" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/md.svg" width="22"> <img title="Limba Română" alt="Limba Română" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/ro.svg" width="22">](README.ro.md)</kbd>
-<kbd>[<img title="မြန်မာ" alt="မြန်မာ" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/mm.svg" width="22">](README.mm_unicode.md)</kbd>
-<kbd>[<img title="Македонски" alt="Македонски" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/mk.svg" width="22">](README.mk.md)</kbd>
-<kbd>[<img title="Español de México" alt="Español de México" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/mx.svg" width="22">](README.mx.md)</kbd>
-<kbd>[<img title="Bahasa Melayu / بهاس ملايو‎ / Malay" alt="Bahasa Melayu / بهاس ملايو‎ / Malay" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/my.svg" width="22">](README.my.md)</kbd>
-<kbd>[<img title="Dutch" alt="Dutch" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/nl.svg" width="22">](README.nl.md)</kbd>
-<kbd>[<img title="Norsk" alt="Norsk" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/no.svg" width="22">](README.no.md)</kbd>
-<kbd>[<img title="नेपाली" alt="नेपाली" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/np.svg" width="15">](README.np.md)</kbd>
-<kbd>[<img title="Wikang Filipino" alt="Wikang Filipino" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/ph.svg" width="22">](README.fil.md)</kbd>
-<kbd>[<img title="English (Pirate)" alt="English (Pirate)" src="https://firstcontributions.github.io/assets/Readme/pirate.png" width="22">](README.en-pirate.md)</kbd>
-<kbd>[<img title="اُاردو" alt="اردو" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/pk.svg" width="22">](README.ur.md)</kbd>
-<kbd>[<img title="Twi (Ghana)" alt="Twi (Ghana)" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/gh.svg" width="22">](README.gh.md)</kbd>
-<kbd>[<img title="Polski" alt="Polski" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/pl.svg" width="22">](README.pl.md)</kbd>
-<kbd>[<img title="Português (Portugal)" alt="Português (Portugal)" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/pt.svg" width="22">](README.pt-pt.md)</kbd>
-<kbd>[<img title="Русский язык" alt="Русский язык" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/ru.svg" width="22">](README.ru.md)</kbd>
-<kbd>[<img title="العربية" alt="العربية" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/sa.svg" width="22">](README.ar.md)</kbd>
-<kbd>[<img title="Svenska" alt="Svenska" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/se.svg" width="22">](README.se.md)</kbd>
-<kbd>[<img title="Slovenčina" alt="Slovenčina" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/sk.svg" width="22">](README.slk.md)</kbd>
-<kbd>[<img title="Slovenščina" alt="Slovenščina" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/si.svg" width="22">](README.sl.md)</kbd>
-<kbd>[<img title="ภาษาไทย" alt="ภาษาไทย" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/th.svg" width="22">](README.th.md)</kbd>
-<kbd>[<img title="Türkçe" alt="Türkçe" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/tr.svg" width="22">](README.tr.md)</kbd>
-<kbd>[<img title="中文(Traditional)" alt="中文(Traditional)" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/tw.svg" width="22">](README.zh-tw.md)</kbd>
-<kbd>[<img title="Українська" alt="Українська" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/ua.svg" width="22">](README.ua.md)</kbd>
-<kbd>[<img title="Tiếng Việt" alt="Tiếng Việt" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/vn.svg" width="22">](README.vn.md)</kbd>
-<kbd>[<img title="Tanzania" alt="Swahili language" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/tz.svg" width="22">](README.sw.md)</kbd>
-<kbd>[<img title="Zulu (South Africa)" alt="Zulu (South Africa)" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/za.svg" width="22">](README.zul.md)</kbd>
-<kbd>[<img title="Afrikaans (South Africa)" alt="Afrikaans (South Africa)" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/za.svg" width="22">](README.afk.md)</kbd>
-<kbd>[<img title="Igbo (Nigeria)" alt="Igbo (Nigeria)" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/ng.svg" width="22">](README.igb.md)</kbd>
-<kbd>[<img title="Bambara (Mali)" alt="Bambara (Mali)" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/ml.svg" width="22">](README.mli.md)</kbd>
-<kbd>[<img title="Hausa (Nigeria)" alt="Hausa (Nigeria)" src="https://upload.wikimedia.org/wikipedia/commons/thumb/5/5d/Flag_of_the_Hausa_people.svg/1280px-Flag_of_the_Hausa_people.svg.png" width="22">](README.hau.md)</kbd>
-<kbd>[<img title="Yoruba (Nigeria)" alt="Yoruba (Nigeria)" src="https://www.fotw.info/images/n/ng%7Deoyor.gif" width="22">](README.yor.md)</kbd>
-<kbd>[<img title="Latvia" alt="Latvia" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/lv.svg" width="22">](README.lv.md)</kbd>
-<kbd>[<img title="Suomeksi" alt="Suomeksi" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/fi.svg" width="22">](README.fi.md)</kbd>
-<kbd>[<img title="Беларуская мова" alt="Беларуская мова" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/by.svg" width="22">](README.be.md)</kbd>
-<kbd>[<img title="Српски" alt="Српски" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/rs.svg" width="22">](README.sr-Cyrl.md)</kbd>
-<kbd>[<img title="Srpski" alt="Srpski" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/rs.svg" width="22">](README.sr-Latn.md)</kbd>
-<kbd>[<img title="Қазақша" alt="Қазақша" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/kz.svg" width="22">](README.kz.md)</kbd>
-<kbd>[<img title="Bosanski" alt="Bosanski" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/ba.svg" width="22">](README.bih.md)</kbd>
-<kbd>[<img title="Hrvatski" alt="Hrvatski" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/hr.svg" width="22">](README.hr.md)</kbd>
-<kbd>[<img title="پښتو" alt="پښتو" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/af.svg" width="22">](README.ps.md)</kbd>
-<kbd>[<img title="Af-soomaali" alt="Somalia" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/so.svg" width="22">](README.so.md)</kbd>
-<kbd>[<img title="Español de Ecuador" alt="Ecuador" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/ec.svg" width="22">](README.ec.md)</kbd>
-<kbd>[<img title="Luganda (Uganda)" alt="Luganda (Uganda)" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/ug.svg" width="22">](README.lug.md)</kbd>
-<kbd>[<img title="Turkmen" alt="Turkmen language" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/tm.svg" width="22">](README.tm.md)</kbd>
-<kbd>[<img title="Ewe (TOGO)" alt="Ewe (TOGO)" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/tg.svg" width="22">](README.ewe.md)</kbd>
-<kbd>[<img title="አማርኛ" alt="አማርኛ" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/et.svg" width="22">](README.am.md)</kbd>
-<kbd>[<img title="Kurdî" alt="Kurdî" src="https://upload.wikimedia.org/wikipedia/commons/3/35/Flag_of_Kurdistan.svg" width="22">](README.kr.md)</kbd>
-<kbd>[<img title="Malagasy" alt="Malagasy" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/mg.svg" width="22">](README.mg.md)</kbd>
-<kbd>[<img title="ភាសាខ្មែរ" alt="ភាសាខ្មែរ" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/kh.svg" width="22">](README.kh.md)</kbd>
-<kbd>[<img title="Morocco" alt="Moroccan Darija" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/ma.svg" width="22">](README.ma.md)</kbd>
-<kbd>[<img title="Mongolian" alt="Mongolian" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/mn.svg" width="22">](README.mn.md)</kbd>
-<kbd>[<img title="Tounsi" alt="Tounsi" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/tn.svg" width="22">](README.tn.md)</kbd>
-<kbd>[<img title="Lingala" alt="Lingala" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/cd.svg" width="22">](README.ln.md)</kbd>
-
 # Første bidrag
 
 Det er alltid vanskelig å gjøre noe for første gang. Spesielt når man samarbeider med andre kan det være tungt å gjøre feil. Vi ønsker å gjøre det lettere for nybegynnere å bidra til open-source.
@@ -232,10 +146,3 @@ Nå kan du gå videre og bidra til andre open-source prosjekter. Vi har satt sam
 | <a href="../gui-tool-tutorials/github-desktop-tutorial.md"><img alt="GitHub Desktop" src="https://desktop.github.com/images/desktop-icon.svg" width="100"></a> | <a href="../gui-tool-tutorials/github-windows-vs2017-tutorial.md"><img alt="Visual Studio 2017" src="https://upload.wikimedia.org/wikipedia/commons/c/cd/Visual_Studio_2017_Logo.svg" width="100"></a> | <a href="../gui-tool-tutorials/gitkraken-tutorial.md"><img alt="GitKraken" src="https://firstcontributions.github.io/assets/gui-tool-tutorials/gitkraken-tutorial/gk-icon.png" width="100"></a> | <a href="../gui-tool-tutorials/github-windows-vs-code-tutorial.md"><img alt="VS Code" src="https://upload.wikimedia.org/wikipedia/commons/1/1c/Visual_Studio_Code_1.35_icon.png" width=100></a> | <a href="../gui-tool-tutorials/sourcetree-macos-tutorial.md"><img alt="Sourcetree App" src="https://wac-cdn.atlassian.com/dam/jcr:81b15cde-be2e-4f4a-8af7-9436f4a1b431/Sourcetree-icon-blue.svg" width=100></a> | <a href="../gui-tool-tutorials/github-windows-intellij-tutorial.md"><img alt="IntelliJ IDEA" src="https://upload.wikimedia.org/wikipedia/commons/thumb/9/9c/IntelliJ_IDEA_Icon.svg/960px-IntelliJ_IDEA_Icon.svg.png" width=100></a> |
 | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [GitHub Desktop](../gui-tool-tutorials/github-desktop-tutorial.md)                                                                                             | [Visual Studio 2017](../gui-tool-tutorials/github-windows-vs2017-tutorial.md)                                                                                                                          | [GitKraken](../gui-tool-tutorials/gitkraken-tutorial.md)                                                                                                                                        | [Visual Studio Code](../gui-tool-tutorials/github-windows-vs-code-tutorial.md)                                                                                                                  | [Atlassian Sourcetree](../gui-tool-tutorials/sourcetree-macos-tutorial.md)                                                                                                                                      | [IntelliJ IDEA](../gui-tool-tutorials/github-windows-intellij-tutorial.md)                                                                                                                                                          |
-
-<p>Dette prosjektet er støttet av:</p>
-<p>
-  <a href="https://www.digitalocean.com/">
-    <img src="https://opensource.nyc3.cdn.digitaloceanspaces.com/attribution/assets/SVG/DO_Logo_horizontal_blue.svg" width="201px">
-  </a>
-</p>

--- a/docs/translations/README.no.md
+++ b/docs/translations/README.no.md
@@ -2,7 +2,91 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 [![Open Source Helpers](https://www.codetriage.com/roshanjossey/first-contributions/badges/users.svg)](https://www.codetriage.com/roshanjossey/first-contributions)
 
-
+#### _Les dette på [andre språk](Translations.md)._
+<kbd>[<img title="Shqip" alt="Shqip" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/al.svg" width="22">](README.sq.md)</kbd>
+<kbd>[<img title="Armenian" alt="Armenian" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/am.svg" width="22">](README.arm.md)</kbd>
+<kbd>[<img title="Uzbek" alt="Uzbek language" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/uz.svg" width="22">](README.uz.md)</kbd>
+<kbd>[<img title="Azərbaycan dili" alt="Azərbaycan dili" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/az.svg" width="22">](README.aze.md)</kbd>
+<kbd>[<img title="বাংলা" alt="বাংলা" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/bd.svg" width="22">](README.bn.md)</kbd>
+<kbd>[<img title="Bulgarian" alt="Bulgarian" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/bg.svg" width="22">](README.bg.md)</kbd>
+<kbd>[<img title="Português (Brasil)" alt="Português (Brasil)" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/br.svg" width="22">](README.pt_br.md)</kbd>
+<kbd>[<img title="Català" alt="Català" src="https://firstcontributions.github.io/assets/Readme/catalan1.png" width="22">](README.ca.md)</kbd>
+<kbd>[<img title="中文 (Simplified)" alt="中文 (Simplified)" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/cn.svg" width="22">](README.zh-cn.md)</kbd>
+<kbd>[<img title="Czech" alt="Czech" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/cz.svg" width="22">](README.cs.md)</kbd>
+<kbd>[<img title="Deutsch" alt="Deutsch" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/de.svg" width="22">](README.de.md)</kbd>
+<kbd>[<img title="Dansk" alt="Dansk" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/dk.svg" width="22">](README.da.md)</kbd>
+<kbd>[<img title="المصرية" alt="المصرية" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/eg.svg" width="22">](README.eg.md)</kbd>
+<kbd>[<img title="Dezéiriya" alt="Dezéiriya" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/dz.svg" width="22">](README.dz.md)</kbd>
+<kbd>[<img title="Español de España" alt="Español de España" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/es.svg" width="22">](README.es.md)</kbd>
+<kbd>[<img title="Française" alt="Française" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/fr.svg" width="22">](README.fr.md)</kbd>
+<kbd>[<img title="Gaeilge" alt="Gaeilge" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/ie.svg" width="22">](README.ga.md)</kbd>
+<kbd>[<img title="Galego" alt="Galego" src="https://upload.wikimedia.org/wikipedia/commons/6/64/Flag_of_Galicia.svg" width="22">](README.gl.md)</kbd>
+<kbd>[<img title="Ελληνικά" alt="Ελληνικά" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/gr.svg" width="22">](README.gr.md)</kbd>
+<kbd>[<img title="ქართული" alt="ქართული" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/ge.svg" width="22">](README.ge.md)</kbd>
+<kbd>[<img title="Magyar" alt="Magyar" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/hu.svg" width="22">](README.hu.md)</kbd>
+<kbd>[<img title="Bahasa Indonesia" alt="Bahasa Indonesia" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/id.svg" width="22">](README.id.md)</kbd>
+<kbd>[<img title="עִברִית" alt="עִברִית" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/il.svg" width="22">](README.hb.md)</kbd>
+<kbd>[<img title="ગુજરાતી / हिन्दी / मराठी / മലയാളം / ಕನ್ನಡ / తెలుగు / ଓଡିଆ / છત્તીસગઢી / ਪੰਜਾਬੀ" alt="ગુજરાતી / हिन्दी / मराठी / മലയാളം / ಕನ್ನಡ / తెలుగు / ଓଡିଆ / છત્તીસગઢી / ਪੰਜਾਬੀ" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/in.svg" width="22">](Translations.md)</kbd>
+<kbd>[<img title="தமிழ்" alt="தமிழ்" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/lk.svg" width="22">](README.ta.md)</kbd>
+<kbd>[<img title="فارسی" alt="فارسی" src="https://upload.wikimedia.org/wikipedia/commons/b/ba/Flag_of_Iran_before_1979_Revolution.svg" width="22">](README.fa.md)</kbd>
+<kbd>[<img title="Italiano" alt="Italiano" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/it.svg" width="22">](README.it.md)</kbd>
+<kbd>[<img title="日本語" alt="日本語" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/jp.svg" width="22">](README.ja.md)</kbd>
+<kbd>[<img title="සිංහල" alt="සිංහල" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/lk.svg" width="22">](README.si.md)</kbd>
+<kbd>[<img title="한국어" alt="한국어" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/kr.svg" width="22">](README.ko.md)</kbd>
+<kbd>[<img title="Lietuvių kalba" alt="Lietuvių kalba" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/lt.svg" width="22">](README.lt.md)</kbd>
+<kbd>[<img title="Limba Română" alt="Limba Română" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/md.svg" width="22"> <img title="Limba Română" alt="Limba Română" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/ro.svg" width="22">](README.ro.md)</kbd>
+<kbd>[<img title="မြန်မာ" alt="မြန်မာ" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/mm.svg" width="22">](README.mm_unicode.md)</kbd>
+<kbd>[<img title="Македонски" alt="Македонски" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/mk.svg" width="22">](README.mk.md)</kbd>
+<kbd>[<img title="Español de México" alt="Español de México" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/mx.svg" width="22">](README.mx.md)</kbd>
+<kbd>[<img title="Bahasa Melayu / بهاس ملايو‎ / Malay" alt="Bahasa Melayu / بهاس ملايو‎ / Malay" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/my.svg" width="22">](README.my.md)</kbd>
+<kbd>[<img title="Dutch" alt="Dutch" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/nl.svg" width="22">](README.nl.md)</kbd>
+<kbd>[<img title="Norsk" alt="Norsk" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/no.svg" width="22">](README.no.md)</kbd>
+<kbd>[<img title="नेपाली" alt="नेपाली" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/np.svg" width="15">](README.np.md)</kbd>
+<kbd>[<img title="Wikang Filipino" alt="Wikang Filipino" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/ph.svg" width="22">](README.fil.md)</kbd>
+<kbd>[<img title="English (Pirate)" alt="English (Pirate)" src="https://firstcontributions.github.io/assets/Readme/pirate.png" width="22">](README.en-pirate.md)</kbd>
+<kbd>[<img title="اُاردو" alt="اردو" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/pk.svg" width="22">](README.ur.md)</kbd>
+<kbd>[<img title="Twi (Ghana)" alt="Twi (Ghana)" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/gh.svg" width="22">](README.gh.md)</kbd>
+<kbd>[<img title="Polski" alt="Polski" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/pl.svg" width="22">](README.pl.md)</kbd>
+<kbd>[<img title="Português (Portugal)" alt="Português (Portugal)" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/pt.svg" width="22">](README.pt-pt.md)</kbd>
+<kbd>[<img title="Русский язык" alt="Русский язык" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/ru.svg" width="22">](README.ru.md)</kbd>
+<kbd>[<img title="العربية" alt="العربية" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/sa.svg" width="22">](README.ar.md)</kbd>
+<kbd>[<img title="Svenska" alt="Svenska" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/se.svg" width="22">](README.se.md)</kbd>
+<kbd>[<img title="Slovenčina" alt="Slovenčina" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/sk.svg" width="22">](README.slk.md)</kbd>
+<kbd>[<img title="Slovenščina" alt="Slovenščina" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/si.svg" width="22">](README.sl.md)</kbd>
+<kbd>[<img title="ภาษาไทย" alt="ภาษาไทย" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/th.svg" width="22">](README.th.md)</kbd>
+<kbd>[<img title="Türkçe" alt="Türkçe" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/tr.svg" width="22">](README.tr.md)</kbd>
+<kbd>[<img title="中文(Traditional)" alt="中文(Traditional)" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/tw.svg" width="22">](README.zh-tw.md)</kbd>
+<kbd>[<img title="Українська" alt="Українська" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/ua.svg" width="22">](README.ua.md)</kbd>
+<kbd>[<img title="Tiếng Việt" alt="Tiếng Việt" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/vn.svg" width="22">](README.vn.md)</kbd>
+<kbd>[<img title="Tanzania" alt="Swahili language" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/tz.svg" width="22">](README.sw.md)</kbd>
+<kbd>[<img title="Zulu (South Africa)" alt="Zulu (South Africa)" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/za.svg" width="22">](README.zul.md)</kbd>
+<kbd>[<img title="Afrikaans (South Africa)" alt="Afrikaans (South Africa)" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/za.svg" width="22">](README.afk.md)</kbd>
+<kbd>[<img title="Igbo (Nigeria)" alt="Igbo (Nigeria)" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/ng.svg" width="22">](README.igb.md)</kbd>
+<kbd>[<img title="Bambara (Mali)" alt="Bambara (Mali)" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/ml.svg" width="22">](README.mli.md)</kbd>
+<kbd>[<img title="Hausa (Nigeria)" alt="Hausa (Nigeria)" src="https://upload.wikimedia.org/wikipedia/commons/thumb/5/5d/Flag_of_the_Hausa_people.svg/1280px-Flag_of_the_Hausa_people.svg.png" width="22">](README.hau.md)</kbd>
+<kbd>[<img title="Yoruba (Nigeria)" alt="Yoruba (Nigeria)" src="https://www.fotw.info/images/n/ng%7Deoyor.gif" width="22">](README.yor.md)</kbd>
+<kbd>[<img title="Latvia" alt="Latvia" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/lv.svg" width="22">](README.lv.md)</kbd>
+<kbd>[<img title="Suomeksi" alt="Suomeksi" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/fi.svg" width="22">](README.fi.md)</kbd>
+<kbd>[<img title="Беларуская мова" alt="Беларуская мова" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/by.svg" width="22">](README.be.md)</kbd>
+<kbd>[<img title="Српски" alt="Српски" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/rs.svg" width="22">](README.sr-Cyrl.md)</kbd>
+<kbd>[<img title="Srpski" alt="Srpski" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/rs.svg" width="22">](README.sr-Latn.md)</kbd>
+<kbd>[<img title="Қазақша" alt="Қазақша" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/kz.svg" width="22">](README.kz.md)</kbd>
+<kbd>[<img title="Bosanski" alt="Bosanski" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/ba.svg" width="22">](README.bih.md)</kbd>
+<kbd>[<img title="Hrvatski" alt="Hrvatski" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/hr.svg" width="22">](README.hr.md)</kbd>
+<kbd>[<img title="پښتو" alt="پښتو" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/af.svg" width="22">](README.ps.md)</kbd>
+<kbd>[<img title="Af-soomaali" alt="Somalia" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/so.svg" width="22">](README.so.md)</kbd>
+<kbd>[<img title="Español de Ecuador" alt="Ecuador" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/ec.svg" width="22">](README.ec.md)</kbd>
+<kbd>[<img title="Luganda (Uganda)" alt="Luganda (Uganda)" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/ug.svg" width="22">](README.lug.md)</kbd>
+<kbd>[<img title="Turkmen" alt="Turkmen language" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/tm.svg" width="22">](README.tm.md)</kbd>
+<kbd>[<img title="Ewe (TOGO)" alt="Ewe (TOGO)" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/tg.svg" width="22">](README.ewe.md)</kbd>
+<kbd>[<img title="አማርኛ" alt="አማርኛ" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/et.svg" width="22">](README.am.md)</kbd>
+<kbd>[<img title="Kurdî" alt="Kurdî" src="https://upload.wikimedia.org/wikipedia/commons/3/35/Flag_of_Kurdistan.svg" width="22">](README.kr.md)</kbd>
+<kbd>[<img title="Malagasy" alt="Malagasy" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/mg.svg" width="22">](README.mg.md)</kbd>
+<kbd>[<img title="ភាសាខ្មែរ" alt="ភាសាខ្មែរ" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/kh.svg" width="22">](README.kh.md)</kbd>
+<kbd>[<img title="Morocco" alt="Moroccan Darija" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/ma.svg" width="22">](README.ma.md)</kbd>
+<kbd>[<img title="Mongolian" alt="Mongolian" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/mn.svg" width="22">](README.mn.md)</kbd>
+<kbd>[<img title="Tounsi" alt="Tounsi" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/tn.svg" width="22">](README.tn.md)</kbd>
+<kbd>[<img title="Lingala" alt="Lingala" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/cd.svg" width="22">](README.ln.md)</kbd>
 
 # Første bidrag
 
@@ -10,24 +94,21 @@ Det er alltid vanskelig å gjøre noe for første gang. Spesielt når man samarb
 
 Å lese artikler og se videoer kan hjelpe, men hva kan vel være bedre enn å gjøre det i praksis? Dette prosjektet håper å kunne tilby en enkel veiledning og gjøre det lett for nybegynnere å gi sitt første bidrag. Følg trinnene nedenfor hvis du ønsker å gi ditt første bidrag til dette prosjektet.
 
-_Hvis du ikke er komfortabel med terminal, [så finnes det andre metoder med bruk av GUI.](#tutorials-using-other-tools)_
-
-#### Om du ikke har git installert på din maskin, [følg denne veiledningen](https://help.github.com/articles/set-up-git/).
-<br/><br/>
-
-## Fork dette prosjektet
+_Hvis du ikke er komfortabel med terminal, [så finnes det andre metoder med bruk av GUI.](#veiledning-for-andre-verktøy)_
 
 <img align="right" width="300" src="https://firstcontributions.github.io/assets/Readme/fork.png" alt="fork dette prosjektet" />
 
+#### Om du ikke har git installert på din maskin, [følg denne veiledningen](https://help.github.com/articles/set-up-git/).
+
+## Fork dette prosjektet
+
 Fork prosjektet ved å klikke på "fork" knappen på toppen av denne siden. Dette vil legge til en kopi av dette prosjektet til din GitHub konto (prosjekter kalles repository på GitHub).
-<br/><br/>
-<br/><br/>
 
 ## Clone prosjektet
 
 <img align="right" width="300" src="https://firstcontributions.github.io/assets/Readme/clone.png" alt="klon dette prosjektet" />
 
-Nå skal vi klone prosjektet fra GitHub til din maskin. Gå til din GitHub konto og åpne din nye fork, deretter klikk på "clone" knappen og kopier linken.
+Nå skal vi klone prosjektet fra GitHub til din maskin. Gå til din GitHub konto og åpne din nye fork, deretter klikk på "code" knappen og kopier linken.
 
 Åpne en terminal/kommandolinje og kjør følgende git kommando:
 
@@ -46,8 +127,6 @@ git clone https://github.com/ditt-brukernavn/first-contributions.git
 ```
 
 der `ditt-brukernavn` er ditt GitHub brukernavn. Her kopierer vi innholdet i first-contributions prosjektet fra din GitHub konto til din lokale maskin.
-<br/><br/>
-<br/><br/>
 
 ## Opprett en branch
 
@@ -68,8 +147,8 @@ Eksempel:
 ```bash
 git checkout -b add-alonzo-church
 ```
+
 Navnet på din branch behøver ikke å inneholde ordet _add_, men det gir mening å inkludere det i denne sammenhengen. Endre "alonzo-church" til ditt navn.
-<br/><br/>
 
 ## Lag nødvendige endringer og commit dem
 
@@ -80,7 +159,6 @@ Navnet på din branch behøver ikke å inneholde ordet _add_, men det gir mening
 Hvis du åpner terminalen igjen og kjører kommandoen `git status`, vil du se dine endringer.
 
 Legg endringene til i din nye branch med kommandoen `git add`:
-
 
 ```bash
 git add Contributors.md
@@ -93,7 +171,6 @@ git commit -m "Add <ditt-navn> to Contributors list"
 ```
 
 Erstatt `<ditt-navn>` med ditt navn.
-<br/><br/>
 
 ## Push endringene til GitHub
 
@@ -108,14 +185,23 @@ Erstatt `<navn-på-din-branch>` med navnet på branch som du opprettet tidligere
 <details>
 <summary> <strong>Hvis du får noen feilmeldinger når du pusher til Github, klikk her:</strong> </summary>
 
-- ### Authentication Error
+- ### Autentiseringsfeil
      <pre>remote: Support for password authentication was removed on August 13, 2021. Please use a personal access token instead.
   remote: Please see https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/ for more information.
-  fatal: Authentication failed for 'https://github.com/&lt;your-username&gt;/first-contributions.git/'</pre>
-  Gå til [GitHub's brukansvisning](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account) med generering og konfigurering av SHH nøkkelen til kontoen din.
+  fatal: Authentication failed for 'https://github.com/&lt;ditt-brukernavn&gt;/first-contributions.git/'</pre>
+  Gå til [GitHubs veiledning](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account) for generering og konfigurering av SSH-nøkkel til kontoen din.
 
+  Du kan også sjekke din eksterne adresse med `git remote -v`.
+  Hvis det ser slik ut:
+  <pre>origin	https://github.com/ditt-brukernavn/ditt-repo.git (fetch)
+  origin	https://github.com/ditt-brukernavn/ditt-repo.git (push)</pre>
+
+  endre det med denne kommandoen:
+  ```bash
+  git remote set-url origin git@github.com:ditt-brukernavn/ditt-repo.git
+  ```
+  Ellers vil du fortsatt bli bedt om brukernavn og passord og få autentiseringsfeil.
 </details>
-<br/><br/>
 
 ## Send inn endringene for gjennomgang
 
@@ -128,7 +214,6 @@ Send inn din pull request når du er klar.
 <img style="float: right;" src="https://firstcontributions.github.io/assets/Readme/submit-pull-request.png" alt="send inn pull request" />
 
 Snart vil jeg merge dine endringer inn i master branch av mitt prosjekt. Du vil motta en notifikasjon på epost når dine endringer er lagt til.
-<br/><br/>
 
 ## Hva nå?
 
@@ -136,19 +221,19 @@ Gratulerer! Du har gjennomført standardprosessen for _fork -> clone -> edit -> 
 
 Feir ditt bidrag og del det med dine venner og følgere ved å gå til [web app](https://firstcontributions.github.io/#social-share).
 
-Hvis du vil ha mer øvelse, sjekk [code contributions](https://github.com/roshanjossey/code-contributions).
+Hvis du vil ha mer øvelse, sjekk ut [code contributions](https://github.com/roshanjossey/code-contributions).
 
-Nå kan du gå videre og bidra til andre open-source prosjekter. Vi har satt sammen en liste med enkle og overkommelige problemer du kan starte med. Sjekk den ut her: [the list of projects in the web app](https://firstcontributions.github.io/#project-list).
-<br/><br/>
+Nå kan du gå videre og bidra til andre open-source prosjekter. Vi har satt sammen en liste med enkle og overkommelige problemer du kan starte med. Sjekk den ut her: [listen over prosjekter i webappen](https://firstcontributions.github.io/#project-list).
 
 ### [Ekstramateriale](../additional-material/git_workflow_scenarios/additional-material.md)
+
 ## Veiledning for andre verktøy
 
 | <a href="../gui-tool-tutorials/github-desktop-tutorial.md"><img alt="GitHub Desktop" src="https://desktop.github.com/images/desktop-icon.svg" width="100"></a> | <a href="../gui-tool-tutorials/github-windows-vs2017-tutorial.md"><img alt="Visual Studio 2017" src="https://upload.wikimedia.org/wikipedia/commons/c/cd/Visual_Studio_2017_Logo.svg" width="100"></a> | <a href="../gui-tool-tutorials/gitkraken-tutorial.md"><img alt="GitKraken" src="https://firstcontributions.github.io/assets/gui-tool-tutorials/gitkraken-tutorial/gk-icon.png" width="100"></a> | <a href="../gui-tool-tutorials/github-windows-vs-code-tutorial.md"><img alt="VS Code" src="https://upload.wikimedia.org/wikipedia/commons/1/1c/Visual_Studio_Code_1.35_icon.png" width=100></a> | <a href="../gui-tool-tutorials/sourcetree-macos-tutorial.md"><img alt="Sourcetree App" src="https://wac-cdn.atlassian.com/dam/jcr:81b15cde-be2e-4f4a-8af7-9436f4a1b431/Sourcetree-icon-blue.svg" width=100></a> | <a href="../gui-tool-tutorials/github-windows-intellij-tutorial.md"><img alt="IntelliJ IDEA" src="https://upload.wikimedia.org/wikipedia/commons/thumb/9/9c/IntelliJ_IDEA_Icon.svg/960px-IntelliJ_IDEA_Icon.svg.png" width=100></a> |
 | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [GitHub Desktop](../gui-tool-tutorials/github-desktop-tutorial.md)                                                                                             | [Visual Studio 2017](../gui-tool-tutorials/github-windows-vs2017-tutorial.md)                                                                                                                          | [GitKraken](../gui-tool-tutorials/gitkraken-tutorial.md)                                                                                                                                        | [Visual Studio Code](../gui-tool-tutorials/github-windows-vs-code-tutorial.md)                                                                                                                  | [Atlassian Sourcetree](../gui-tool-tutorials/sourcetree-macos-tutorial.md)                                                                                                                                      | [IntelliJ IDEA](../gui-tool-tutorials/github-windows-intellij-tutorial.md)                                                                                                                                                          |
 
-<p>This project is supported by:</p>
+<p>Dette prosjektet er støttet av:</p>
 <p>
   <a href="https://www.digitalocean.com/">
     <img src="https://opensource.nyc3.cdn.digitaloceanspaces.com/attribution/assets/SVG/DO_Logo_horizontal_blue.svg" width="201px">


### PR DESCRIPTION
﻿## Description

This PR updates the Norwegian translation (README.no.md) to match the current English version:

### Changes
- Added the language flags bar at the top (synced from English version)
- Added the authentication error troubleshooting section in Norwegian
- Updated the fork step to use the current GitHub UI ("code" button)
- Fixed the anchor link to point to the Norwegian section heading
- Added sponsor section in Norwegian

Addresses #119322
