### PR TITLE
docs: fix typos in contribution guide

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -4,16 +4,16 @@ We appreciate your thought to contribute to open source. :heart:
 
 As this might be a starting point for people looking to contribute to open source projects in general. We'll include some general guidelines here.
 
-It's best to think less in terms of what you can do to contribute and more in terms of what maintainers of the project wants. Look for issues that maintainers have labeled as https://github.com/firstcontributions/first-contributions/labels/help%20wanted https://github.com/firstcontributions/first-contributions/labels/good%20first%20issue. This means that maintainers of that project has looked at that issue and would like someone to address it.
+It's best to think less in terms of what you can do to contribute and more in terms of what maintainers of the project want. Look for issues that maintainers have labeled as https://github.com/firstcontributions/first-contributions/labels/help%20wanted https://github.com/firstcontributions/first-contributions/labels/good%20first%20issue. This means that maintainers of that project have looked at that issue and would like someone to address it.
 
-Go through Contribution guidelines that have in the repository (generally Contributing.md). Pay attention to the details in there. It's very important.
+Go through the contribution guidelines in the repository (generally Contributing.md). Pay attention to the details in there. It's very important.
 
-### On llms, coding agents and everything marketted as AI
+### On LLMs, coding agents and everything marketed as AI
 
 It's best to use them as a tool for learning and not to do your work for you.
 
-- It's best to write comments yourself. If you're copy pasting what llm generated, maitainers are communicating with llms.
-- Test things yourself, verify details yourself. llms make mistakes all the time. You don't have to parrot those mistakes.
+- It's best to write comments yourself. If you're copy-pasting what an LLM generated, maintainers are communicating with LLMs.
+- Test things yourself, verify details yourself. LLMs make mistakes all the time. You don't have to parrot those mistakes.
 - Push changes you understand. You should be able to explain yourself why you made a choice.
 
 
@@ -21,5 +21,5 @@ It's best to use them as a tool for learning and not to do your work for you.
 
 1. Don't make changes in Readme.md
 2. Take a look at our design decisions before suggesting changes https://github.com/firstcontributions/first-contributions/issues/35892.
-3. Create new branches for different changes. Checkout main branch and create new branches from there
+3. Create new branches for different changes. Check out the main branch and create new branches from there
 4. Keep pull requests small. A pull request that has one file change is way easier to review than 20 files.


### PR DESCRIPTION
## Summary

- Fix typos and grammar in `.github/CONTRIBUTING.md`
- Standardize LLM/LLMs capitalization in the contribution guide

## Why

This makes the contribution guide clearer for new contributors.

## Testing

- Documentation-only change.
- Verified that only `.github/CONTRIBUTING.md` was changed.
- Ran `git diff --check` locally with no whitespace errors.
