### PR TITLE
Add Santiago Satragni to Contributors.md

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -2761,6 +2761,7 @@ bhumika
 - [sznbatista04-design](https://github.com/sznbatista04-design)
 - [Lucas Lima de Barros](https://github.com/lucaslimadebarros-star)
 - [Fauzan](https://github.com/fauzan660)
+- [Santiago Satragni](https://github.com/santisatragni)
 <<<<<<< HEAD
 - [Ajwa Shahid](https://github.com/ajwashahid150-source)
 =======


### PR DESCRIPTION
## Summary
- Adds my name and GitHub profile link to the Contributors.md list, following this project's first-PR practice workflow.

## Test plan
- N/A (documentation-only change, list entry appended in a clean section of the file)