### PR TITLE
docs(zh-cn): add GitHub Desktop section and sync translation with English README

### DIFF
--- a/docs/translations/README.zh-cn.md
+++ b/docs/translations/README.zh-cn.md
@@ -1,4 +1,4 @@
-[![Open Source Love](https://badges.frapsoft.com/os/v1/open-source.svg?v=103)](https://github.com/ellerbrock/open-source-badges/)
+[![Open Source Love](https://firstcontributions.github.io/open-source-badges/badges/open-source-v1/open-source.svg)](https://github.com/firstcontributions/open-source-badges)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 [![Open Source Helpers](https://www.codetriage.com/roshanjossey/first-contributions/badges/users.svg)](https://www.codetriage.com/roshanjossey/first-contributions)
 
@@ -24,7 +24,7 @@ _如果你对 command line（命令行）不熟悉，请参考以下的 [GUI 工
 
 <img align="right" width="300" src="https://firstcontributions.github.io/assets/Readme/clone.png" alt="克隆此仓库代码" />
 
-接下来将复制的代码仓库克隆到你的电脑上。点击图示中的绿色按钮，接着点击复制到剪切板按钮（将代码仓库地址复制下来）。
+接下来将复制的代码仓库克隆到你的电脑上。在你的 GitHub 账户中打开复制的代码仓库，点击 Code 按钮，然后点击 SSH 标签页，接着点击 _复制到剪贴板_ 图标。
 
 随后打开命令行窗口，敲入如下 Git 命令：
 
@@ -148,15 +148,12 @@ git push -u origin <新分支的名称>
 
 ### [附加材料](../additional-material/git_workflow_scenarios/additional-material.md)
 
+## 使用 GitHub Desktop
+
+如果你不习惯使用命令行，[这里有一份使用 GitHub Desktop 的教程](../gui-tool-tutorials/translations/Chinese/github-desktop-tutorial.zh-cn.md)。
+
 ## 使用其他工具的教程
 
 | <a href="../gui-tool-tutorials/translations/Chinese/github-desktop-tutorial.zh-cn.md"><img alt="GitHub Desktop" src="https://desktop.github.com/images/desktop-icon.svg" width="100"></a> | <a href="../gui-tool-tutorials/github-windows-vs2017-tutorial.md"><img alt="Visual Studio 2017" src="https://upload.wikimedia.org/wikipedia/commons/c/cd/Visual_Studio_2017_Logo.svg" width="100"></a> | <a href="../gui-tool-tutorials/translations/Chinese/gitkraken-tutorial-zh-cn.md"><img alt="GitKraken" src="https://firstcontributions.github.io/assets/gui-tool-tutorials/gitkraken-tutorial/gk-icon.png" width="100"></a> | <a href="../gui-tool-tutorials/github-windows-vs-code-tutorial.md"><img alt="VS Code" src="https://upload.wikimedia.org/wikipedia/commons/1/1c/Visual_Studio_Code_1.35_icon.png" width=100></a> | <a href="../gui-tool-tutorials/sourcetree-macos-tutorial.md"><img alt="Sourcetree App" src="https://wac-cdn.atlassian.com/dam/jcr:81b15cde-be2e-4f4a-8af7-9436f4a1b431/Sourcetree-icon-blue.svg" width=100></a> | <a href="../gui-tool-tutorials/github-windows-intellij-tutorial.zh-cn.md"><img alt="IntelliJ IDEA" src="https://upload.wikimedia.org/wikipedia/commons/thumb/9/9c/IntelliJ_IDEA_Icon.svg/512px-IntelliJ_IDEA_Icon.svg.png" width=100></a> |
 | --- | --- | --- | --- | --- | --- |
 | [GitHub Desktop](../gui-tool-tutorials/translations/Chinese/github-desktop-tutorial.zh-cn.md) | [Visual Studio 2017](../gui-tool-tutorials/github-windows-vs2017-tutorial.md) | [GitKraken](../gui-tool-tutorials/translations/Chinese/gitkraken-tutorial-zh-cn.md) | [Visual Studio Code](../gui-tool-tutorials/github-windows-vs-code-tutorial.md) | [Atlassian Sourcetree](../gui-tool-tutorials/sourcetree-macos-tutorial.md) | [IntelliJ IDEA](../gui-tool-tutorials/github-windows-intellij-tutorial.zh-cn.md) |
-
-<p>项目支持者:</p>
-<p>
-  <a href="https://www.digitalocean.com/">
-    <img src="https://opensource.nyc3.cdn.digitaloceanspaces.com/attribution/assets/SVG/DO_Logo_horizontal_blue.svg" width="201px">
-  </a>
-</p>


### PR DESCRIPTION
This PR updates the Simplified Chinese README (`translations/README.zh-cn.md`) to keep it in sync with the upstream English README. 

**Changes included:**
- Added the missing "Using GitHub Desktop" (使用 GitHub Desktop) section with a link to the Chinese GitHub Desktop tutorial.
- Updated the "Open Source Love" badge URL to match the current URL in the English README.
- Updated the cloning instructions to correctly mention the "SSH" tab, keeping it aligned with upstream.
- Fixed a minor typo in the cloning instructions ("剪切板" -> "剪贴板").
- Removed the outdated DigitalOcean sponsor section which is no longer present in the English README.
