### PR TITLE
Improve contributor PR validation and conflict feedback

### DIFF
--- a/.github/workflows/auto-pr-merge.yml
+++ b/.github/workflows/auto-pr-merge.yml
@@ -1,267 +1,172 @@
-name: Auto-merge PRs
+name: Validate and merge contributor PRs
+
 on:
   pull_request_target:
-    types: [opened, synchronize]
+    types: [opened, reopened, ready_for_review, synchronize]
     paths:
-      - 'Contributors.md' # <- only run if only contributors file changed
-    
-jobs:
-  auto-merge:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-      issues: write
-      
-    steps:
-      # Check out the repository code
-      - name: Checkout code
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 2
+      - Contributors.md
 
-      - name: Check if PR only modifies Contributors.md and number of changes
-        id: is_only_contributors_file_changed
-        uses: actions/github-script@v8
-        with: 
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  validate-and-merge:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate contribution and merge
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const { data: files } = await github.rest.pulls.listFiles({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.issue.number
+            const marker = '<!-- first-contributions-auto-merge -->';
+            const { owner, repo } = context.repo;
+            const pullNumber = context.payload.pull_request.number;
+            const pullRequest = context.payload.pull_request;
+
+            async function upsertFeedback(body) {
+              const comments = await github.paginate(
+                github.rest.issues.listComments,
+                { owner, repo, issue_number: pullNumber, per_page: 100 }
+              );
+              const existing = comments.find(comment =>
+                comment.user.type === 'Bot' && comment.body?.includes(marker)
+              );
+              const markedBody = `${marker}\n${body}`;
+
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner,
+                  repo,
+                  comment_id: existing.id,
+                  body: markedBody
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number: pullNumber,
+                  body: markedBody
+                });
+              }
+            }
+
+            const files = await github.paginate(
+              github.rest.pulls.listFiles,
+              { owner, repo, pull_number: pullNumber, per_page: 100 }
+            );
+            const contributorFile = files.find(file => file.filename === 'Contributors.md');
+            const onlyContributorFile = files.length === 1 && contributorFile;
+
+            if (!onlyContributorFile) {
+              const changedFiles = files.map(file => `- \`${file.filename}\``).join('\n');
+              await upsertFeedback(
+                `### Maintainer review needed\n\n` +
+                `Hi @${pullRequest.user.login}, this pull request changes files other than ` +
+                `\`Contributors.md\`, so it won't be merged automatically. A maintainer will review it.\n\n` +
+                `Changed files:\n${changedFiles}`
+              );
+              return;
+            }
+
+            const addedLines = (contributorFile.patch || '')
+              .split('\n')
+              .filter(line => line.startsWith('+') && !line.startsWith('+++'))
+              .map(line => line.slice(1));
+            const contributorPattern = /^-\s+\[[^\]\r\n]+\]\(https:\/\/github\.com\/[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})(?:\/)?\)\s*$/;
+            const isOneValidEntry =
+              contributorFile.additions === 1 &&
+              contributorFile.deletions === 0 &&
+              addedLines.length === 1 &&
+              contributorPattern.test(addedLines[0]);
+
+            if (!isOneValidEntry) {
+              await upsertFeedback(
+                `### Please update your contribution\n\n` +
+                `Hi @${pullRequest.user.login}, this exercise expects exactly one new line in ` +
+                `\`Contributors.md\` and no removed lines. Use this format:\n\n` +
+                '```markdown\n- [Your Name](https://github.com/your-github-username)\n```\n\n' +
+                `Push the correction to the same branch. This check will run again automatically; ` +
+                `you don't need to open another pull request.`
+              );
+              core.setFailed('The pull request must add exactly one valid contributor entry.');
+              return;
+            }
+
+            const latest = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: pullNumber
             });
 
-            const filenames = files.map(f => f.filename);
-            const isOnlyContributors = filenames.length === 1 && filenames[0] === 'Contributors.md';
-
-            const { additions, deletions } = context.payload.pull_request;
-            const isLinesChangedUnderThreshod = (additions < 5 && deletions < 4);
-
-            core.setOutput('only_contributors', isOnlyContributors && isLinesChangedUnderThreshod);
-            core.setOutput('filenames', filenames.join(', '));
-
-            const moreLineChanged = (isOnlyContributors && !isLinesChangedUnderThreshod)
-
-            // set true if multiple changed if only isOnlyContributors 
-            core.setOutput('isMultipleLineChanged', moreLineChanged)
-
-            // is multiple file changed
-            core.setOutput('isMultipleFilesChanged', !isOnlyContributors)
-            
-            if (!isOnlyContributors) {
-              console.log(`Validation Failed: Files changed: ${filenames.join(', ')}`);
+            if (latest.data.mergeable === false || latest.data.mergeable_state === 'dirty') {
+              await postConflictFeedback();
+              core.setFailed('The pull request has a merge conflict.');
+              return;
             }
 
-      # Merge the pull request if it only modifies the Contributors.md file or if it fail to do then drop failure message as post 
-      - name: Merge PR
-        id: merge_pr
-        if: steps.is_only_contributors_file_changed.outputs.only_contributors == 'true'
-        uses: actions/github-script@v8
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const { owner, repo } = context.repo;
-            const pr = context.payload.pull_request;
-            const username = pr.user.login;
+            async function postConflictFeedback() {
+              await upsertFeedback(
+                `### Update needed: merge conflict\n\n` +
+                `Hi @${pullRequest.user.login}, your contributor entry is valid, but another ` +
+                `contribution was merged into \`main\` and this pull request now has a conflict. ` +
+                `Update your branch with these commands:\n\n` +
+                '```bash\n' +
+                'git remote add upstream https://github.com/firstcontributions/first-contributions.git\n' +
+                'git fetch upstream\n' +
+                `git checkout ${pullRequest.head.ref}\n` +
+                'git merge upstream/main\n' +
+                '```\n\n' +
+                `Open \`Contributors.md\`, remove the \`<<<<<<<\`, \`=======\`, and ` +
+                `\`>>>>>>>\` markers, and keep both contributors' entries. Then run:\n\n` +
+                '```bash\n' +
+                'git add Contributors.md\n' +
+                'git commit -m "Resolve Contributors.md conflict"\n' +
+                `git push origin ${pullRequest.head.ref}\n` +
+                '```\n\n' +
+                `This check will run again automatically. You don't need to open another pull request. ` +
+                `For more detail, see the [merge conflict guide]` +
+                `(https://github.com/firstcontributions/first-contributions/blob/main/docs/additional-material/git_workflow_scenarios/resolving-merge-conflicts.md).`
+              );
+            }
 
             try {
-            // Attempt to merge the pull request using the squash method
-             const response = await github.rest.pulls.merge({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: pr.number,
-               merge_method: "squash"
-             })
+              const result = await github.rest.pulls.merge({
+                owner,
+                repo,
+                pull_number: pullNumber,
+                merge_method: 'squash',
+                sha: pullRequest.head.sha
+              });
 
-            // Check if the merge was successful by checking the status code of the response
-             if (response.status === 200) {
-
-                const celebrationGifs = [
-                  'https://c.tenor.com/ZCq4SwgCfxAAAAAC/snoopy-peanuts.gif',
-                  'https://c.tenor.com/Z0ojZS2kpO0AAAAC/milk-and-mocha-happy.gif',
-                  'https://c.tenor.com/LffD4a8ET9AAAAAC/heart-celebrate.gif',
-                  'https://c.tenor.com/HJ0iSKwIG28AAAAC/yes-baby.gif',
-                  'https://c.tenor.com/4blWuIh5MIYAAAAC/baby-yoda.gif',
-                  'https://c.tenor.com/B_zYdea4l-4AAAAC/yay-minions.gif',
-                  'https://c.tenor.com/JHndvQVcsBUAAAAC/fern-pat-fern-good-job.gif',
-                  'https://media1.giphy.com/media/artj92V8o75VPL7AeQ/giphy.gif',
-                  'https://media2.giphy.com/media/IwAZ6dvvvaTtdI8SD5/giphy.gif',
-                  'https://media0.giphy.com/media/z8gtBVdZVrH20/giphy.gif',
-                  'https://media1.giphy.com/media/LZElUsjl1Bu6c/giphy.gif',
-                  'https://media1.giphy.com/media/gHnwTttExPf4nwOWm7/giphy.gif',
-                ]
-
-                const getRandomGif = () => celebrationGifs[Math.floor(Math.random() * celebrationGifs.length)]
-
-                // social media links
-                const web_url = 'https://firstcontributions.github.io';
-                const codeContributionsLink = 'https://github.com/roshanjossey/code-contributions'
-                const fb_share_link = 'https://www.facebook.com/sharer/sharer.php?u=https://roshanjossey.github.io/first-contributions&quote=Yay%21%20I%20just%20made%20my%20first%20open%20source%20contribution%20with%20First%20Contributions.%20You%20can%20too,%20by%20following%20a%20simple%20tutorial%20at%20https%3A//goo.gl/66Axwe&hashtag=%23OpenSource'
-                const reddit_link = 'https://www.reddit.com/submit?url=https%3A%2F%2Fgithub.com%2Ffirstcontributions%2Ffirst-contributions&title=Learn%20how%20to%20contribute%20to%20open%20source%20projects%20in%205%20minutes'
-                const linkedin_share_link = 'https://www.linkedin.com/sharing/share-offsite/?url=https://github.com/firstcontributions/first-contributions';
-                const dev_share_link = "https://dev.to/new?prefill=---%0Atitle%3A%20First%20Contributions%3A%20learn%20how%20to%20contribute%20to%20open%20source%20projects%0Apublished%3A%20true%0Atags%3A%20opensource%2C%20beginners%2C%20tutorial%0A---%0A%0AI%20followed%20the%20hands-on%20tutorial%20in%20the%20Readme%20of%20first%20contributions%20and%20made%20my%20first%20pull%20request%20to%20the%20same%20repo.%0A%0A%0A%7B%25%20embed%20https%3A%2F%2Fgithub.com%2Ffirstcontributions%2Ffirst-contributions%20%25%7D";
-                const hackernews_share_link = 'https://news.ycombinator.com/submitlink?u=https%3A%2F%2Fgithub.com%2Ffirstcontributions%2Ffirst-contributions&t=Show%20HN%3A%20Hands%20on%20tutorial%20for%20open%20source%20contribution'
-                const bluesky_share_link = 'https://bsky.app/intent/compose?text=Yay%21%20I%20just%20made%20my%20first%20open%20source%20contribution%20with%20%40FirstContributions.%20You%20can%20too%20by%20following%20a%20simple%20tutorial%20at%20https%3A%2F%2Fgoo.gl%2F66Axwe%20%23OpenSource%20%23FirstContribution%20%23Coding%20%23DevCommunity%20%23GitHub%20%23LearnToCode';
-                
-                // social logo
-                const repo_logo = "https://avatars0.githubusercontent.com/u/65761570?s=88&u=640f39b808c75c6b86460aa907dd030bcca2f3c7&v=4"
-                const fb_logo = "https://edent.github.io/SuperTinyIcons/images/svg/facebook.svg"
-                const reddit_logo = "https://edent.github.io/SuperTinyIcons/images/svg/reddit.svg"
-                const linkedin_logo = "https://edent.github.io/SuperTinyIcons/images/svg/linkedin.svg";
-                const dev_logo = "https://edent.github.io/SuperTinyIcons/images/svg/dev_to.svg";
-                const hackernews_logo = "https://edent.github.io/SuperTinyIcons/images/svg/hackernews.svg";
-                const bluesky_logo = "https://edent.github.io/SuperTinyIcons/images/svg/bluesky.svg";
-
-
-                const getMergeMessage = (username) => {
-                  const greeting = `Hello @${username}, congratulations! You've successfully submitted a pull request. 🎉`;
-                  const starRepoMessage = `If you liked the tutorial, please star this repo by clicking the star button on the top right of this page. <img alt="star screenshot" title="star button" src="https://firstcontributions.github.io/assets/star.png">`;
-                  
-                  const nextSteps = `# Next steps \n - Continue contributing: If you're looking for projects to contribute to, checkout our [<img src="${repo_logo}" width="22" title="web app" /> webapp](${web_url}). \n - If you want more practice checkout [code contributions](${codeContributionsLink}). \n - Share on social media: You can share this content to help more people.\n   - [<img alt="bluesky" title="bluesky" src="${bluesky_logo}" width="22"> Post on Bluesky](${bluesky_share_link}).\n   - [<img alt="facebook" title="facebook" src="${fb_logo}" width="22"> share](${fb_share_link}).\n   - [ <img alt="reddit" title="reddit" src="${reddit_logo}" width="22"> share](${reddit_link}).\n   - [<img alt="linkedin" title="linkedin" src="${linkedin_logo}" width="22"> post](${linkedin_share_link}).\n   - [<img alt="devio" title="devio" src="${dev_logo}" width="22"> publish](${dev_share_link}).\n   - [<img src="${hackernews_logo}" width="22" title="HackerNews" /> Post on HackerNews](${hackernews_share_link}).`;
-                  const feedbackMessage = `We'd love to hear your thoughts about this project. Let us know how we can improve by commenting or opening an issue here.`;
-                  
-                  const gif = `![celebration gif](${getRandomGif()})`;
-
-                  return `${greeting}\n\n${starRepoMessage}\n\n${nextSteps}\n\n${feedbackMessage}\n\n${gif}`;
-                }
-
-                // Generate the merge message using the getMergeMessage function
-                const message = getMergeMessage(context.payload.pull_request.user.login);
-
-                // post a comment
-                await github.rest.issues.createComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: context.issue.number,
-                  body: message
-                })
-
-             } else {
-              
-              // Post a comment on the pull request using the createComment method
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: pr.number,
-                body: "Something went wrong while attempting to merge this pull request. Please check the GitHub Actions log for more information."
-               })
-            }
-             } catch (error) {
-
-              let errMsg = "";
-              console.error("Error merging pull request:", error.message);
-
-              // Handle specific error cases based on status code
-              if (error.status === 405 && error.response.data.message === "Pull Request is not mergeable") {
-
-              //  errMsg = `Hello @${context.payload.pull_request.user.login}, thank you for your pull request. We appreciate your contribution to the project. However, before we can merge it, there is a merge conflict with the target branch.  \n\n No worries! You can follow [this guide](https://github.com/firstcontributions/first-contributions/blob/main/docs/additional-material/git_workflow_scenarios/resolving-merge-conflicts.md) on resolving merge conflicts. 
-              //  Once you've fixed the conflicts and pushed your changes, the repository will check the changes you made and proceed with the merge if everything looks good.  \n\n If you have any questions or need further assistance, don't hesitate to reach out. We're here to help!`
-              
-              errMsg =  `### 🛠️ Merge Conflict\nHi @${username}, another contributor edited the file at the same time! Follow [this guide](https://github.com/firstcontributions/first-contributions/blob/main/docs/additional-material/git_workflow_scenarios/resolving-merge-conflicts.md) to resolve the conflict.`
-
-              } else if (error.status === 409) {
-                console.error("The pull request has conflicts with the target branch. Resolve the conflicts before merging.");
-                errMsg = "The pull request has conflicts with the target branch. Resolve the conflicts before merging.";
-
-              } else {
-                console.error("Something went wrong while merging the pull request.");
-                errMsg = "Something went wrong while merging the pull request.";
+              if (!result.data.merged) {
+                throw new Error(result.data.message || 'GitHub did not merge the pull request.');
               }
 
-              // Post a comment on the pull request using the createComment method
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: pr.number,
-                body: errMsg
-               })
+              await upsertFeedback(
+                `### Contribution merged\n\n` +
+                `Congratulations @${pullRequest.user.login}! Your contributor entry passed the ` +
+                `automated checks and has been merged.`
+              );
+            } catch (error) {
+              const refreshed = await github.rest.pulls.get({
+                owner,
+                repo,
+                pull_number: pullNumber
+              });
 
-              // Set GitHub Action as failed
-              core.setFailed(error.message);
-            }
-
-      # Post a comment on the pull request if it was not merged automatically
-      - name: Manual Review Notification
-        # Check if the pull request only modifies the CONTRIBUTORS.md file
-        if: steps.is_only_contributors_file_changed.outputs.only_contributors == 'false'
-        uses: actions/github-script@v8
-        env:
-          # keep fileames into the enviroment better prevent from any injection
-          RAW_FILES: ${{ steps.is_only_contributors_file_changed.outputs.filenames }}
-          IS_MULTIPLES_LINES_CHANGES: ${{ steps.is_only_contributors_file_changed.outputs.isMultipleLineChanged}}
-          IS_MULTIPLES_FILES_CHANGES: ${{steps.is_only_contributors_file_changed.outputs.isMultipleFilesChanged}}
-        with:
-          script: |
-            const isMultipleFilesChanged = process.env.IS_MULTIPLES_FILES_CHANGES === 'true';
-            const isMultipleLinesChanged = process.env.IS_MULTIPLES_LINES_CHANGES === 'true';
-            const { owner, repo } = context.repo;
-            const pr = context.payload.pull_request;
-            const username = pr.user.login;
-
-            let body;
-            let labels = [];
-            let isReviewRequired = false;
-
-
-            if(isMultipleFilesChanged){
-              // Get files from env (safe from injection)
-              const filesString = process.env.RAW_FILES || "";
-
-              // Format file list
-              const fileList = filesString
-                .split(', ')
-                .filter(f => f.trim() !== "")
-                .map(file => `- ${file}`)
-                .join('\n');
-
-              body = `### 🌟 Hello @${username}! \n\nThank you for this contribution. Since this PR modifies files beyond the tutorial (\`Contributors.md\`), I've flagged this for a **manual review** by our maintainers. \n\nThe following files were changed:\n\n${fileList} \n\nWe appreciate you helping improve the project!`;
-              labels = ['👩‍💻 waiting for review'];
-            
-            } else if (!isMultipleFilesChanged && isMultipleLinesChanged){
-              
-              const totalChanges = pr.additions + pr.deletions;
-              let diffBlock = "";
-              
-              if (totalChanges > 0 && totalChanges <= 5) {
-                const { data: files } = await github.rest.pulls.listFiles({
-                   owner: context.repo.owner, repo: context.repo.repo, pull_number: pr.number
-                 });
-                
-                const patch = files[0]?.patch ? `\`\`\`diff\n${files[0].patch}\n\`\`\`` : "_No preview available_";
-
-                diffBlock = `\n\n**Preview of changes:**\n${patch}`;
-
-              } else{
-                diffBlock = `\n\nNo preview available.`;
+              if (refreshed.data.mergeable === false || refreshed.data.mergeable_state === 'dirty') {
+                await postConflictFeedback();
+                core.setFailed('The pull request developed a merge conflict.');
+                return;
               }
-                body = `### 👋 Hi @${username}! \n\nGreat job reaching the final step! However, it looks like there are **${totalChanges} lines of changes**.\n\n${diffBlock} \n\nThe tutorial works best when you add exactly **one line**. Please [follow tutorial](https://github.com/firstcontributions/first-contributions?tab=readme-ov-file#make-necessary-changes-and-commit-those-changes) carefully. \n\nWe're excited to have you in the community!`
-                isReviewRequired = true;
+
+              await upsertFeedback(
+                `### Maintainer review needed\n\n` +
+                `Your contributor entry passed validation, but GitHub couldn't merge it ` +
+                `automatically. A maintainer will review the pull request.`
+              );
+              throw error;
             }
-
-
-            // get the existing comments.
-            const {data: comments} = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.number,
-            })
-
-            // find any comment already made by the bot.                                                                                                    
-            const botComment = comments.find(comment => comment.user.login === 'github-actions[bot]')                                                                       
-
-            if (body) {
-
-              // Add Labels
-              if (labels.length > 0) await github.rest.issues.addLabels({ owner, repo, issue_number: pr.number, labels });
-
-              if (isReviewRequired) {
-                await github.rest.pulls.createReview({ owner, repo, pull_number: pr.number, body, event: 'REQUEST_CHANGES' });
-              } else if (botComment) {
-                await github.rest.issues.updateComment({ owner, repo, comment_id: botComment.id, body });
-              } else {
-                await github.rest.issues.createComment({ owner, repo, issue_number: pr.number, body });
-              }
-            }
-            
-          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Replace the existing broad contributor auto-merge logic with deterministic validation and reusable participant feedback.

- require exactly one added `Contributors.md` entry and no deletions for automatic merging
- validate the new entry's Markdown and GitHub profile URL
- explain how to correct invalid submissions on the same PR
- detect merge conflicts and provide beginner-friendly update and resolution commands
- update one marked bot comment instead of posting duplicates
- fall back to maintainer review for other files or unexpected merge failures
- pin `actions/github-script` to the v8.0.0 commit SHA
- avoid checking out or executing code from untrusted forks

This keeps the existing direct squash-merge behavior for valid contributor PRs while giving participants actionable feedback when concurrent submissions conflict.

## Validation

- `actionlint .github/workflows/auto-pr-merge.yml`
- VS Code GitHub Actions schema validation
- `git diff --check`