### PR TITLE
docs: fix typo, missing word, and capitalization in additional-info

### DIFF
--- a/docs/additional-material/git_workflow_scenarios/additional-material.md
+++ b/docs/additional-material/git_workflow_scenarios/additional-material.md
@@ -11,20 +11,20 @@ This document provides information about how to configure user details and other
 > Use this to better control your git configurations.
 
 ### [Keeping your fork synced with the repository](keeping-your-fork-synced-with-this-repository.md)
-This document provides information about how to keep your forked repository up-to-date with the base repository. This is important, as hopefully you and many others will contribute to the project.
+This document provides information about how to keep your forked repository up-to-date with the base repository. This is important, as you and many others will contribute to the project.
 > Follow these steps if your fork doesn't have any changes in parent repository.
 
-### [Moving a Commit to a different Branch](moving-a-commit-to-a-different-branch.md)
-This document provides information about how to move a Commit to another Branch.
+### [Moving a commit to a different branch](moving-a-commit-to-a-different-branch.md)
+This document provides information about how to move a commit to another branch.
 > Take these steps to move a commit to another branch.
 
 ### [Removing a File](removing-a-file.md)
 This document provides information about how to remove a file from your local repository.
-> Follow these steps to learn how to remove a file prior to a commit
+> Follow these steps to learn how to remove a file prior to a commit.
 
 ### [Removing a branch from your repository](removing-branch-from-your-repository.md)
 This document provides information about how to delete a branch from your repository.
-> Only after your pull request gets merged, follow to next steps
+> Only after your pull request gets merged, follow the next steps.
 
 ### [Resolving Merge Conflicts](resolving-merge-conflicts.md)
 This document provides information about how to resolve merge conflicts.
@@ -38,7 +38,7 @@ This document provides information about how to revert a commit on the remote re
 This document provides information about how to squash commits with an interactive rebase.
 > Use this if you want to open a PR in an open source project and the reviewer asks you to squash every commit into one, with an informative commit message.
 
-### [Undo-ing a local commit](undoing-a-commit.md)
+### [Undoing a local commit](undoing-a-commit.md)
 This document provides information about how to undo a commit on your local repository. This is what you need to do when you feel you've messed up your local repository and wish to reset the local repository.
 > Take these steps if you want to undo/reset a local commit.
 


### PR DESCRIPTION
- Fixed "Undo-ing" → "Undoing"
- Added missing "the" in removing branch section
- Fixed incorrect capitalization of "Commit" and "Branch"

Before submitting this pull request, check the changes to see it's only the changes you made intentionally
If there are changes to other lines you didn't make deliberately, it's possible that your IDE made the changes with a utility like prettier.
Next time, make sure that you only add your changes by using `git add -p` and rather than `git add Contributors.md`

If you're doing something in the checklist below, put an `x` inside `[ ]` so that `- [ ]` becomes `- [x]`

- [ ] I had fun going through this tutorial (ノ^o^)ノ and learned on the way ٩(＾◡＾)۶
- [ ] There are some things I'd like to improve in this tutorial. I have written them below.
- [ ] There were steps where I had errors while following this tutorial. I have written them below.