### PR TITLE
Add Haitian Creole translation (README.ht.md)

### DIFF
--- a/docs/translations/README.ht.md
+++ b/docs/translations/README.ht.md
@@ -1,0 +1,246 @@
+[![Open Source Love](https://firstcontributions.github.io/open-source-badges/badges/open-source-v1/open-source.svg)](https://github.com/firstcontributions/open-source-badges)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
+[![Open Source Helpers](https://www.codetriage.com/roshanjossey/first-contributions/badges/users.svg)](https://www.codetriage.com/roshanjossey/first-contributions)
+
+#### _Read this in [other languages](docs/translations/Translations.md)._
+<kbd>[<img title="Shqip" alt="Shqip" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/al.svg" width="22">](docs/translations/README.sq.md)</kbd>
+<kbd>[<img title="Armenian" alt="Armenian" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/am.svg" width="22">](docs/translations/README.arm.md)</kbd>
+<kbd>[<img title="Uzbek" alt="Uzbek language" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/uz.svg" width="22">](docs/translations/README.uz.md)</kbd>
+<kbd>[<img title="Azərbaycan dili" alt="Azərbaycan dili" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/az.svg" width="22">](docs/translations/README.aze.md)</kbd>
+<kbd>[<img title="বাংলা" alt="বাংলা" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/bd.svg" width="22">](docs/translations/README.bn.md)</kbd>
+<kbd>[<img title="Bulgarian" alt="Bulgarian" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/bg.svg" width="22">](docs/translations/README.bg.md)</kbd>
+<kbd>[<img title="Português (Brasil)" alt="Português (Brasil)" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/br.svg" width="22">](docs/translations/README.pt_br.md)</kbd>
+<kbd>[<img title="Català" alt="Català" src="https://firstcontributions.github.io/assets/Readme/catalan1.png" width="22">](docs/translations/README.ca.md)</kbd>
+<kbd>[<img title="中文 (Simplified)" alt="中文 (Simplified)" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/cn.svg" width="22">](docs/translations/README.zh-cn.md)</kbd>
+<kbd>[<img title="Czech" alt="Czech" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/cz.svg" width="22">](docs/translations/README.cs.md)</kbd>
+<kbd>[<img title="Deutsch" alt="Deutsch" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/de.svg" width="22">](docs/translations/README.de.md)</kbd>
+<kbd>[<img title="Dansk" alt="Dansk" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/dk.svg" width="22">](docs/translations/README.da.md)</kbd>
+<kbd>[<img title="المصرية" alt="المصرية" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/eg.svg" width="22">](docs/translations/README.eg.md)</kbd>
+<kbd>[<img title="Dezéiriya" alt="Dezéiriya" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/dz.svg" width="22">](docs/translations/README.dz.md)</kbd>
+<kbd>[<img title="Español de España" alt="Español de España" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/es.svg" width="22">](docs/translations/README.es.md)</kbd>
+<kbd>[<img title="Française" alt="Française" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/fr.svg" width="22">](docs/translations/README.fr.md)</kbd>
+<kbd>[<img title="Kreyòl Ayisyen" alt="Kreyòl Ayisyen" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/ht.svg" width="22">](docs/translations/README.ht.md)</kbd>
+<kbd>[<img title="Gaeilge" alt="Gaeilge" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/ie.svg" width="22">](docs/translations/README.ga.md)</kbd>
+<kbd>[<img title="Galego" alt="Galego" src="https://upload.wikimedia.org/wikipedia/commons/6/64/Flag_of_Galicia.svg" width="22">](docs/translations/README.gl.md)</kbd>
+<kbd>[<img title="Ελληνικά" alt="Ελληνικά" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/gr.svg" width="22">](docs/translations/README.gr.md)</kbd>
+<kbd>[<img title="ქართული" alt="ქართული" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/ge.svg" width="22">](docs/translations/README.ge.md)</kbd>
+<kbd>[<img title="Magyar" alt="Magyar" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/hu.svg" width="22">](docs/translations/README.hu.md)</kbd>
+<kbd>[<img title="Bahasa Indonesia" alt="Bahasa Indonesia" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/id.svg" width="22">](docs/translations/README.id.md)</kbd>
+<kbd>[<img title="עִברִית" alt="עִברִית" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/il.svg" width="22">](docs/translations/README.hb.md)</kbd>
+<kbd>[<img title="ગુજરાતી / हिन्दी / मराठी / മലയാളം / ಕನ್ನಡ / తెలుగు / ଓଡିଆ / छत्तीसगढ़ी / ਪੰਜਾਬੀ/کٲشُر" alt="ગુજરાતી / हिन्दी / मराठी / മലയാളം / ಕನ್ನಡ / తెలుగు / ଓଡିଆ / छत्तीसगढ़ी / ਪੰਜਾਬੀ/کٲشُر" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/in.svg" width="22">](docs/translations/Translations.md)</kbd>
+<kbd>[<img title="தமிழ்" alt="தமிழ்" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/lk.svg" width="22">](docs/translations/README.ta.md)</kbd>
+<kbd>[<img title="فارسی" alt="فارسی" src="https://upload.wikimedia.org/wikipedia/commons/b/ba/Flag_of_Iran_before_1979_Revolution.svg" width="22">](docs/translations/README.fa.md)</kbd>
+<kbd>[<img title="Italiano" alt="Italiano" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/it.svg" width="22">](docs/translations/README.it.md)</kbd>
+<kbd>[<img title="日本語" alt="日本語" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/jp.svg" width="22">](docs/translations/README.ja.md)</kbd>
+<kbd>[<img title="සිංහල" alt="සිංහල" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/lk.svg" width="22">](docs/translations/README.si.md)</kbd>
+<kbd>[<img title="한국어" alt="한국어" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/kr.svg" width="22">](docs/translations/README.ko.md)</kbd>
+<kbd>[<img title="Lietuvių kalba" alt="Lietuvių kalba" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/lt.svg" width="22">](docs/translations/README.lt.md)</kbd>
+<kbd>[<img title="Limba Română" alt="Limba Română" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/md.svg" width="22"> <img title="Limba Română" alt="Limba Română" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/ro.svg" width="22">](docs/translations/README.ro.md)</kbd>
+<kbd>[<img title="မြန်မာ" alt="မြန်မာ" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/mm.svg" width="22">](docs/translations/README.mm_unicode.md)</kbd>
+<kbd>[<img title="Македонски" alt="Македонски" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/mk.svg" width="22">](docs/translations/README.mk.md)</kbd>
+<kbd>[<img title="Español de México" alt="Español de México" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/mx.svg" width="22">](docs/translations/README.mx.md)</kbd>
+<kbd>[<img title="Bahasa Melayu / بهاس ملايو‎ / Malay" alt="Bahasa Melayu / بهاس ملايو‎ / Malay" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/my.svg" width="22">](docs/translations/README.my.md)</kbd>
+<kbd>[<img title="Dutch" alt="Dutch" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/nl.svg" width="22">](docs/translations/README.nl.md)</kbd>
+<kbd>[<img title="Norsk" alt="Norsk" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/no.svg" width="22">](docs/translations/README.no.md)</kbd>
+<kbd>[<img title="नेपाली" alt="नेपाली" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/np.svg" width="15">](docs/translations/README.np.md)</kbd>
+<kbd>[<img title="Wikang Filipino" alt="Wikang Filipino" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/ph.svg" width="22">](docs/translations/README.fil.md)</kbd>
+<kbd>[<img title="English (Pirate)" alt="English (Pirate)" src="https://firstcontributions.github.io/assets/Readme/pirate.png" width="22">](docs/translations/README.en-pirate.md)</kbd>
+<kbd>[<img title="اُاردو" alt="اردو" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/pk.svg" width="22">](docs/translations/README.ur.md)</kbd>
+<kbd>[<img title="Twi (Ghana)" alt="Twi (Ghana)" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/gh.svg" width="22">](docs/translations/README.gh.md)</kbd>
+<kbd>[<img title="Polski" alt="Polski" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/pl.svg" width="22">](docs/translations/README.pl.md)</kbd>
+<kbd>[<img title="Português (Portugal)" alt="Português (Portugal)" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/pt.svg" width="22">](docs/translations/README.pt-pt.md)</kbd>
+<kbd>[<img title="Русский язык" alt="Русский язык" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/ru.svg" width="22">](docs/translations/README.ru.md)</kbd>
+<kbd>[<img title="العربية" alt="العربية" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/sa.svg" width="22">](docs/translations/README.ar.md)</kbd>
+<kbd>[<img title="Svenska" alt="Svenska" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/se.svg" width="22">](docs/translations/README.se.md)</kbd>
+<kbd>[<img title="Slovenčina" alt="Slovenčina" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/sk.svg" width="22">](docs/translations/README.slk.md)</kbd>
+<kbd>[<img title="Slovenščina" alt="Slovenščina" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/si.svg" width="22">](docs/translations/README.sl.md)</kbd>
+<kbd>[<img title="ภาษาไทย" alt="ภาษาไทย" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/th.svg" width="22">](docs/translations/README.th.md)</kbd>
+<kbd>[<img title="Türkçe" alt="Türkçe" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/tr.svg" width="22">](docs/translations/README.tr.md)</kbd>
+<kbd>[<img title="中文(Traditional)" alt="中文(Traditional)" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/tw.svg" width="22">](docs/translations/README.zh-tw.md)</kbd>
+<kbd>[<img title="Українська" alt="Українська" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/ua.svg" width="22">](docs/translations/README.ua.md)</kbd>
+<kbd>[<img title="Tiếng Việt" alt="Tiếng Việt" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/vn.svg" width="22">](docs/translations/README.vn.md)</kbd>
+<kbd>[<img title="Tanzania" alt="Swahili language" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/tz.svg" width="22">](docs/translations/README.sw.md)</kbd>
+<kbd>[<img title="Zulu (South Africa)" alt="Zulu (South Africa)" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/za.svg" width="22">](docs/translations/README.zul.md)</kbd>
+<kbd>[<img title="Afrikaans (South Africa)" alt="Afrikaans (South Africa)" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/za.svg" width="22">](docs/translations/README.afk.md)</kbd>
+<kbd>[<img title="Igbo (Nigeria)" alt="Igbo (Nigeria)" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/ng.svg" width="22">](docs/translations/README.igb.md)</kbd>
+<kbd>[<img title="Bambara (Mali)" alt="Bambara (Mali)" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/ml.svg" width="22">](docs/translations/README.mli.md)</kbd>
+<kbd>[<img title="Hausa (Nigeria)" alt="Hausa (Nigeria)" src="https://upload.wikimedia.org/wikipedia/commons/thumb/5/5d/Flag_of_the_Hausa_people.svg/1280px-Flag_of_the_Hausa_people.svg.png" width="22">](docs/translations/README.hau.md)</kbd>
+<kbd>[<img title="Yoruba (Nigeria)" alt="Yoruba (Nigeria)" src="https://www.fotw.info/images/n/ng%7Deoyor.gif" width="22">](docs/translations/README.yor.md)</kbd>
+<kbd>[<img title="Latvia" alt="Latvia" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/lv.svg" width="22">](docs/translations/README.lv.md)</kbd>
+<kbd>[<img title="Suomeksi" alt="Suomeksi" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/fi.svg" width="22">](docs/translations/README.fi.md)</kbd>
+<kbd>[<img title="Беларуская мова" alt="Беларуская мова" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/by.svg" width="22">](docs/translations/README.be.md)</kbd>
+<kbd>[<img title="Српски" alt="Српски" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/rs.svg" width="22">](docs/translations/README.sr-Cyrl.md)</kbd>
+<kbd>[<img title="Srpski" alt="Srpski" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/rs.svg" width="22">](docs/translations/README.sr-Latn.md)</kbd>
+<kbd>[<img title="Қазақша" alt="Қазақша" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/kz.svg" width="22">](docs/translations/README.kz.md)</kbd>
+<kbd>[<img title="Bosanski" alt="Bosanski" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/ba.svg" width="22">](docs/translations/README.bih.md)</kbd>
+<kbd>[<img title="Hrvatski" alt="Hrvatski" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/hr.svg" width="22">](docs/translations/README.hr.md)</kbd>
+<kbd>[<img title="پښتو" alt="پښتو" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/af.svg" width="22">](docs/translations/README.ps.md)</kbd>
+<kbd>[<img title="Af-soomaali" alt="Somalia" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/so.svg" width="22">](docs/translations/README.so.md)</kbd>
+<kbd>[<img title="Español de Ecuador" alt="Ecuador" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/ec.svg" width="22">](docs/translations/README.ec.md)</kbd>
+<kbd>[<img title="Luganda (Uganda)" alt="Luganda (Uganda)" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/ug.svg" width="22">](docs/translations/README.lug.md)</kbd>
+<kbd>[<img title="Turkmen" alt="Turkmen language" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/tm.svg" width="22">](docs/translations/README.tm.md)</kbd>
+<kbd>[<img title="Ewe (TOGO)" alt="Ewe (TOGO)" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/tg.svg" width="22">](docs/translations/README.ewe.md)</kbd>
+<kbd>[<img title="አማርኛ" alt="አማርኛ" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/et.svg" width="22">](docs/translations/README.am.md)</kbd>
+<kbd>[<img title="Kurdî" alt="Kurdî" src="https://upload.wikimedia.org/wikipedia/commons/3/35/Flag_of_Kurdistan.svg" width="22">](docs/translations/README.kr.md)</kbd>
+<kbd>[<img title="Malagasy" alt="Malagasy" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/mg.svg" width="22">](docs/translations/README.mg.md)</kbd>
+<kbd>[<img title="ភាសាខ្មែរ" alt="ភាសាខ្មែរ" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/kh.svg" width="22">](docs/translations/README.kh.md)</kbd>
+<kbd>[<img title="Morocco" alt="Moroccan Darija" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/ma.svg" width="22">](docs/translations/README.ma.md)</kbd>
+<kbd>[<img title="Mongolian" alt="Mongolian" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/mn.svg" width="22">](docs/translations/README.mn.md)</kbd>
+<kbd>[<img title="Tounsi" alt="Tounsi" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/tn.svg" width="22">](docs/translations/README.tn.md)</kbd>
+<kbd>[<img title="Lingala" alt="Lingala" src="https://cdn.jsdelivr.net/gh/hampusborgos/country-flags@main/svg/cd.svg" width="22">](docs/translations/README.ln.md)</kbd>
+
+# First Contributions
+
+This project aims to simplify and guide the way beginners make their first contribution. If you are looking to make your first contribution, follow the steps below.
+
+_If you're not comfortable with command line, [here are tutorials using GUI tools.](#tutorials-using-other-tools)_
+
+<img align="right" width="300" src="https://firstcontributions.github.io/assets/Readme/fork.png" alt="fork the repository" />
+
+#### If you don't have git on your machine, [install it](https://docs.github.com/en/get-started/quickstart/set-up-git).
+
+## Fork this repository
+
+Fork this repository by clicking on the fork button on the top of this page.
+This will create a copy of this repository in your account.
+
+## Clone the repository
+
+<img align="right" width="300" src="https://firstcontributions.github.io/assets/Readme/clone.png" alt="clone the repository" />
+
+Now clone the forked repository to your machine. Go to your GitHub account, open the forked repository, click on the code button, then on SSH tab and then click the _copy url to clipboard_ icon.
+
+Open a terminal and run the following git command:
+
+```bash
+git clone "url you just copied"
+```
+
+where "url you just copied" (without the quotation marks) is the url to this repository (your fork of this project). See the previous steps to obtain the url.
+
+<img align="right" width="300" src="https://firstcontributions.github.io/assets/Readme/copy-to-clipboard.png" alt="copy URL to clipboard" />
+
+For example:
+
+```bash
+git clone git@github.com:this-is-you/first-contributions.git
+```
+
+where `this-is-you` is your GitHub username. Here you're copying the contents of the first-contributions repository on GitHub to your computer.
+
+## Create a branch
+
+Change to the repository directory on your computer (if you are not already there):
+
+```bash
+cd first-contributions
+```
+
+Now create a branch using the `git switch` command:
+
+```bash
+git switch -c your-new-branch-name
+```
+
+For example:
+
+```bash
+git switch -c add-alonzo-church
+```
+
+<details>
+<summary> <strong>If you get any errors using git switch, click here:</strong> </summary>
+
+If the error message "Git: `switch` is not a git command. See `git –help`" appears, it's likely because you're using an older version of git.
+
+In this case, try to use `git checkout` instead:
+
+```bash
+git checkout -b your-new-branch-name
+```
+
+</details>
+
+## Make necessary changes and commit those changes
+
+Now open `Contributors.md` file in a text editor, add your name to it. Don't add it at the beginning or end of the file. Put it anywhere in between. Now, save the file.
+
+<img align="right" width="450" src="https://firstcontributions.github.io/assets/Readme/git-status.png" alt="git status" />
+
+If you go to the project directory and execute the command `git status`, you'll see there are changes.
+
+Add those changes to the branch you just created using the `git add` command:
+
+```bash
+git add Contributors.md
+```
+
+Now commit those changes using the `git commit` command:
+
+```bash
+git commit -m "Add your-name to Contributors list"
+```
+
+replacing `your-name` with your name.
+
+## Push changes to GitHub
+
+Push your changes using the command `git push`:
+
+```bash
+git push -u origin your-branch-name
+```
+
+replacing `your-branch-name` with the name of the branch you created earlier.
+
+<details>
+<summary> <strong>If you get any errors while pushing, click here:</strong> </summary>
+
+- ### Authentication Error
+     <pre>remote: Support for password authentication was removed on August 13, 2021. Please use a personal access token instead.
+  remote: Please see https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/ for more information.
+  fatal: Authentication failed for 'https://github.com/&lt;your-username&gt;/first-contributions.git/'</pre>
+  Go to [GitHub's tutorial](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account) on generating and configuring an SSH key to your account.
+
+  Also, you might want to run 'git remote -v' to check your remote address.
+  
+  If it looks anything like this:
+  <pre>origin	https://github.com/your-username/your_repo.git (fetch)
+  origin	https://github.com/your-username/your_repo.git (push)</pre>
+  
+  change it using this command:
+  ```bash
+  git remote set-url origin git@github.com:your-username/your_repo.git
+  ```
+  Otherwise you'll still get prompted for username and password and get authentication error.
+</details>
+
+## Submit your changes for review
+
+If you go to your repository on GitHub, you'll see a `Compare & pull request` button. Click on that button.
+
+<img style="float: right;" src="https://firstcontributions.github.io/assets/Readme/compare-and-pull.png" alt="compare and create pull request" />
+
+Now submit the pull request.
+
+<img style="float: right;" src="https://firstcontributions.github.io/assets/Readme/submit-pull-request.png" alt="submit pull request" />
+
+Soon I'll be merging all your changes into the main branch of this project. You will get a notification email once the changes have been merged.
+
+## Where to go from here?
+
+Congrats! You just completed the standard _fork -> clone -> edit -> pull request_ workflow that you'll often encounter as a contributor!
+
+Celebrate your contribution and share it with your friends and followers by going to [web app](https://firstcontributions.github.io/#social-share).
+
+If you'd like more practice, checkout [code contributions](https://github.com/roshanjossey/code-contributions).
+
+Now let's get you started with contributing to other projects. We've compiled a list of projects with easy issues you can get started on. Check out [the list of projects in the web app](https://firstcontributions.github.io/#project-list).
+
+### [Additional material](docs/additional-material/git_workflow_scenarios/additional-material.md)
+
+## Tutorials Using Other Tools
+
+| <a href="docs/gui-tool-tutorials/github-desktop-tutorial.md"><img alt="GitHub Desktop" src="https://desktop.github.com/images/desktop-icon.svg" width="100"></a> | <a href="docs/gui-tool-tutorials/github-windows-vs2017-tutorial.md"><img alt="Visual Studio 2017" src="https://upload.wikimedia.org/wikipedia/commons/c/cd/Visual_Studio_2017_Logo.svg" width="100"></a> | <a href="docs/gui-tool-tutorials/gitkraken-tutorial.md"><img alt="GitKraken" src="https://firstcontributions.github.io/assets/gui-tool-tutorials/gitkraken-tutorial/gk-icon.png" width="100"></a> | <a href="docs/gui-tool-tutorials/github-windows-vs-code-tutorial.md"><img alt="VS Code" src="https://upload.wikimedia.org/wikipedia/commons/1/1c/Visual_Studio_Code_1.35_icon.png" width=100></a> | <a href="docs/gui-tool-tutorials/sourcetree-macos-tutorial.md"><img alt="Sourcetree App" src="https://wac-cdn.atlassian.com/dam/jcr:81b15cde-be2e-4f4a-8af7-9436f4a1b431/Sourcetree-icon-blue.svg" width=100></a> | <a href="docs/gui-tool-tutorials/github-windows-intellij-tutorial.md"><img alt="IntelliJ IDEA" src="https://upload.wikimedia.org/wikipedia/commons/thumb/9/9c/IntelliJ_IDEA_Icon.svg/960px-IntelliJ_IDEA_Icon.svg.png" width=100></a> |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [GitHub Desktop](docs/gui-tool-tutorials/github-desktop-tutorial.md)                                                                                             | [Visual Studio 2017](docs/gui-tool-tutorials/github-windows-vs2017-tutorial.md)                                                                                                                          | [GitKraken](docs/gui-tool-tutorials/gitkraken-tutorial.md)                                                                                                                                        | [Visual Studio Code](docs/gui-tool-tutorials/github-windows-vs-code-tutorial.md)                                                                                                                  | [Atlassian Sourcetree](docs/gui-tool-tutorials/sourcetree-macos-tutorial.md)                                                                                                                                      | [IntelliJ IDEA](docs/gui-tool-tutorials/github-windows-intellij-tutorial.md)                                                                                                                                                          |


### PR DESCRIPTION
## Description
This PR adds a Haitian Creole (Kreyòl Ayisyen) translation of the README, to make this tutorial accessible to Haitian developers.

## Changes
- Added `docs/translations/README.ht.md`
- Added the Haiti flag link in the main `README.md`, next to the French flag entry

- [x] I had fun going through this tutorial (ノ^o^)ノ and learned on the way ٩(＾◡＾)۶