### PR TITLE
fix: remove unsafe checkout step to resolve pull_request_target error

### DIFF
--- a/.github/workflows/auto-pr-merge.yml
+++ b/.github/workflows/auto-pr-merge.yml
@@ -14,12 +14,7 @@ jobs:
       issues: write
       
     steps:
-      # Check out the repository code
-      - name: Checkout code
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 2
+    
 
       - name: Check if PR only modifies Contributors.md and number of changes
         id: is_only_contributors_file_changed


### PR DESCRIPTION
GitHub recently updated security policies for pull_request_target workflows, blocking actions/checkout from fetching forked PR code to prevent "pwn request" vulnerabilities. Since this auto-merge workflow only uses actions/github-script to interact with the GitHub API, it does not actually need to check out the repository code. Removing this step resolves the security block and allows the auto-merge bot to work for all new contributors again.