### PR TITLE
Add Kavindu Yasintha Silva to contributors

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -501,6 +501,7 @@ niceshowmini
 - [EmmanuelM-A](https://github.com/EmmanuelM-A)
 - [Akanksha Dwivedi](https://github.com/Akanksha-1708)
 - [Krishi](https://github.com/Krishi-bot)
+- [Kavindu Yasintha Silva](https://github.com/kavindyasinthasilva)
 - [Avishkar Dhonde](https://github.com/avishkardhonde23-tech)
 - [vigin pv](https://github.com/vigin-pv)
 - [Affan](https://github.com/)


### PR DESCRIPTION
## What changed

Added Kavindu Yasintha Silva and the corresponding GitHub profile link to `Contributors.md`.

## Why

This completes the repository's first-contribution tutorial.

## Validation

- Confirmed the Markdown link points to the correct GitHub profile.
- Ran `git diff --check`.
