### PR TITLE
Add missing git switch troubleshooting section to README.mx.md

### DIFF
--- a/docs/translations/README.mx.md
+++ b/docs/translations/README.mx.md
@@ -62,6 +62,16 @@ git switch -c add-juan-perez
 ```
 (El nombre de la rama no tiene porqué contener la palabra *add*, pero es razonable que lo tenga porque el objetivo de esta rama es añadir tu nombre a la lista.)
 
+**Si obtienes algún error al usar git switch, haz clic aquí:**
+
+Si aparece el mensaje de error "Git: `switch` no es un comando de git. Consulta `git –help`", es probable que estés usando una versión antigua de Git.
+
+En este caso, intenta usar `git checkout` en su lugar:
+
+```
+git checkout -b <añade tu nombre>
+```
+
 ## Haz los cambios necesarios y guarda (*Commit*) esos cambios
 
 Abre el archivo `Contributors.md` en un editor de texto y añade tu nombre. No lo añadas ni al principio ni al final del archivo, hazlo en cualquier otro sitio. Guarda el archivo.


### PR DESCRIPTION
## What this PR does

Adds the missing troubleshooting note to `docs/translations/README.mx.md` explaining
what to do when the `git switch` command is unavailable (older Git versions).

The English `README.md` includes this note right after the `git switch -c` example,
recommending `git checkout -b` as a fallback. This was missing from the Spanish (Mexico)
translation, causing inconsistency between the two files.

## Changes

- Translated the troubleshooting note from `README.md` into Spanish
- Inserted it in `README.mx.md` in the same location as the source file — right after
  the `git switch -c add-juan-perez` example, before the "Haz los cambios necesarios"
  section
- Kept formatting consistent with the rest of `README.mx.md` (bold lead-in line,
  matching placeholder style `<añade tu nombre>` used elsewhere in the file)

## Why

Spanish-speaking users following this tutorial with an older Git version had no guidance
on how to resolve the `git switch` error, unlike users following the English version.
This keeps both files in sync and unblocks users stuck on that step.

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide (if applicable)
- [x] My changes only affect `docs/translations/README.mx.md`
- [x] I did not change any unrelated lines/formatting
- [x] I verified the translated text is accurate and matches the tone of the rest of the file