### PR TITLE
Add Oliver Radfahrer to Contributors.md

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -3370,3 +3370,4 @@ hey yo!
 - [Nakul Sharma](https://github.com/nakulsharma02)
 - [Priya Dharshini](https://github.com/Dharshukutti)
 - [Samuel Manik](https://github.com/5amuel02)
+- [Oliver Radfahrer](https://github.com/hotchomat)


### PR DESCRIPTION
Adding my name to the Contributors list as part of my first open-source contribution / PR practice.