### PR TITLE
Fix incorrect instructions in Desktop tutorial that cause merge confl…

### DIFF
--- a/docs/gui-tool-tutorials/github-desktop-tutorial.md
+++ b/docs/gui-tool-tutorials/github-desktop-tutorial.md
@@ -60,7 +60,7 @@ Click on `Create branch`
 
 ## Make necessary changes and commit those changes
 
-Now, go to history tab and open `Contributors.md` file in a text editor by right clicking and open in text editor. Scroll to the bottom of the page and add your name to it, then save the file.
+Now, go to history tab and open `Contributors.md` file in a text editor by right clicking and open in text editor. Add your name anywhere in between (don't add it at the beginning or end of the file), then save the file.
 
 Example: If your name is James Smith, It should look like this.
 


### PR DESCRIPTION
### Description
Hello again! I noticed a small contradiction in the documentation that might cause merge conflicts for other beginners. 

The main `README.md` says "Don't add it at the beginning or end of the file", but `docs/gui-tool-tutorials/github-desktop-tutorial.md` told users to "Scroll to the bottom of the page". I updated the desktop tutorial to match the main README's instructions to prevent conflicts!

### Checklist
- [x] I had fun going through this tutorial (ノ^o^)ノ and learned on the way ٩(＾◡＾)۶
- [x] There are some things I'd like to improve in this tutorial. I have written them below.
- [ ] There were steps where I had errors while following this tutorial. I have written them below.
