### PR TITLE
Correct Ayushman-00 contributor entry credit

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -3640,4 +3640,4 @@ Nici30067
 - [Supti Das Medha](https://github.com/Supti-Das-Medha)
 - [Michael_Tucker](https://github.com/micheal-tucker)
 
-- [Ayushman-00](https://github.com/Ayushman-00)
+- [Ayushman Bhardwaj](https://github.com/Ayushman-00)


### PR DESCRIPTION
Replacing the previous incorrect entry with the correct email attribution and name.