### PR TITLE
Clarify HTTPS cloning and authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,25 +107,27 @@ This will create a copy of this repository in your account.
 
 <img align="right" width="300" src="https://firstcontributions.github.io/assets/Readme/clone.png" alt="clone the repository" />
 
-Now clone the forked repository to your machine. Go to your GitHub account, open the forked repository, click on the code button, then on SSH tab and then click the _copy url to clipboard_ icon.
+Now clone the forked repository to your machine. Go to your GitHub account, open the forked repository, click the **Code** button, select the **HTTPS** tab, then click the _copy URL to clipboard_ icon.
 
-Open a terminal and run the following git command:
+Open a terminal and run the following Git command:
 
 ```bash
-git clone "url you just copied"
+git clone "URL you just copied"
 ```
 
-where "url you just copied" (without the quotation marks) is the url to this repository (your fork of this project). See the previous steps to obtain the url.
+where "URL you just copied" (without the quotation marks) is the HTTPS URL for your fork of this project. See the previous steps to obtain the URL.
 
 <img align="right" width="300" src="https://firstcontributions.github.io/assets/Readme/copy-to-clipboard.png" alt="copy URL to clipboard" />
 
 For example:
 
 ```bash
-git clone git@github.com:this-is-you/first-contributions.git
+git clone https://github.com/this-is-you/first-contributions.git
 ```
 
-where `this-is-you` is your GitHub username. Here you're copying the contents of the first-contributions repository on GitHub to your computer.
+where `this-is-you` is your GitHub username. Here you're copying the contents of your fork to your computer.
+
+If you prefer SSH, select the **SSH** tab in the **Code** menu and [set up an SSH key](https://docs.github.com/en/authentication/connecting-to-github-with-ssh) before cloning.
 
 ## Create a branch
 
@@ -196,22 +198,25 @@ replacing `your-branch-name` with the name of the branch you created earlier.
 <summary> <strong>If you get any errors while pushing, click here:</strong> </summary>
 
 - ### Authentication Error
-     <pre>remote: Support for password authentication was removed on August 13, 2021. Please use a personal access token instead.
+
+  <pre>remote: Support for password authentication was removed on August 13, 2021. Please use a personal access token instead.
   remote: Please see https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/ for more information.
   fatal: Authentication failed for 'https://github.com/&lt;your-username&gt;/first-contributions.git/'</pre>
-  Go to [GitHub's tutorial](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account) on generating and configuring an SSH key to your account.
 
-  Also, you might want to run 'git remote -v' to check your remote address.
-  
-  If it looks anything like this:
+  GitHub no longer accepts account passwords for Git operations.
+
+  **If you are using HTTPS**, authenticate with [GitHub CLI or Git Credential Manager](https://docs.github.com/en/get-started/git-basics/caching-your-github-credentials-in-git). These options use a secure browser sign-in and store your credentials for future Git operations.
+
+  **If you prefer SSH**, [set up an SSH key](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account), then update your remote. Run `git remote -v` to check the current remote. If it uses HTTPS, such as:
+
   <pre>origin	https://github.com/your-username/your_repo.git (fetch)
   origin	https://github.com/your-username/your_repo.git (push)</pre>
-  
-  change it using this command:
+
+  change it with:
+
   ```bash
   git remote set-url origin git@github.com:your-username/your_repo.git
   ```
-  Otherwise you'll still get prompted for username and password and get authentication error.
 </details>
 
 ## Submit your changes for review


### PR DESCRIPTION
## Summary
- make HTTPS the default cloning path for new contributors
- retain SSH as a documented alternative
- replace the SSH-only authentication recovery path with current GitHub CLI and Git Credential Manager guidance

## Why
The tutorial is aimed at first-time contributors, but its clone instructions currently assume an SSH setup and its error help sends HTTPS users directly to an SSH-only remedy. This update gives beginners a clear, secure path for either protocol.

## Validation
- verified the branch is one commit ahead of `main`
- verified that only `README.md` changed
- checked the HTTPS and SSH instructions against current GitHub documentation

- [x] I learned the fork, branch, commit, and pull request workflow through this tutorial.
- [x] I found and described an improvement to the tutorial above.