### PR TITLE
Add Gabriel Pinheiro to Contributors list

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -3938,3 +3938,4 @@ Harish K
 abhinav abhinav
 - [Caleb33-del](https://github.com/Caleb33-del)
 - [林清渊](https://github.com/userlinqingyuan)
+- [Gabriel Pinheiro](https://github.com/gabrielpinherotst-ui)


### PR DESCRIPTION
Adding my name to the Contributors list as part of my first contribution / first PR practice.