### PR TITLE
Add Paul Madut to Contributors.md

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -3940,6 +3940,7 @@ abhinav abhinav
 - [Caleb33-del](https://github.com/Caleb33-del)
 - [林清渊](https://github.com/userlinqingyuan)
 - [BujesL](https://github.com/BujesL)
+- [Paul Madut](https://github.com/paul-madut)
 
 - [Gloria Velasco](https://github.com/gvelascopena)
 - [charismile98](https://github.com/charismile98)


### PR DESCRIPTION
Adds my name to `Contributors.md` following the tutorial.

Single line inserted mid-file: 1 addition, 0 deletions, `Contributors.md` only.