### PR TITLE
Fix unresolved merge conflict markers in Contributors.md

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -3970,11 +3970,8 @@ abhinav abhinav
 - [Angel Panayotov](https://github.com/arpanayotov-source)
 - [Sebastian Gebhardt](https://github.com/sebastiangebhardt10-sudo)
 - [Aniruddh523](https://github.com/Aniruddh523)
-<<<<<<< HEAD
-
 - [Anshul Kumar](https://github.com/anshullakra007)
-=======
 - [Mayank Dhanagar](https://github.com/mayankdhanagar)
->>>>>>> b07d95969 (Add Mayank Dhanagar to Contributors list)
 - [Roger](https://github.com/rdemarco13-byte)
 - [Asif Ilyas](https://github.com/Kakaman-Kakaman)
+- [thomasjunius-prog](https://github.com/thomasjunius-prog)


### PR DESCRIPTION
## Summary
- Removes leftover `<<<<<<< HEAD` / `=======` / `>>>>>>> b07d95969` conflict markers that were accidentally committed to `Contributors.md` on main, while keeping both contributor entries (Anshul Kumar and Mayank Dhanagar) that the conflict was between.
- Adds my own entry to the list as my first contribution, per this repo's convention.

## Test plan
- Visually diffed the file before/after to confirm only the conflict markers were removed and no contributor entries were lost.