### PR TITLE
Fix inconsistent GitHub capitalization in desktop tutorial

### DIFF
--- a/docs/gui-tool-tutorials/github-desktop-tutorial.md
+++ b/docs/gui-tool-tutorials/github-desktop-tutorial.md
@@ -13,7 +13,7 @@ Reading articles & watching tutorials can help, but what comes better than actua
 
 If you don't have GitHub Desktop on your machine, [install it](https://desktop.github.com/).
 
-If you're using a version of GitHub desktop before 1.0, [refer to this tutorial](github-desktop-old-version-tutorial.md).
+If you're using a version of GitHub Desktop before 1.0, [refer to this tutorial](github-desktop-old-version-tutorial.md).
 
 <img align="right" width="300" src="https://firstcontributions.github.io/assets/gui-tool-tutorials/github-desktop-tutorial/fork.png" alt="fork this repository" />
 
@@ -28,7 +28,7 @@ Now clone this repo to your machine.
 
 IMPORTANT: DO NOT CLONE THE ORIGINAL REPO. Go to your fork and clone it.
 
-To clone the repo, click on "Code" and then click on "Open in Github Desktop".
+To clone the repo, click on "Code" and then click on "Open in GitHub Desktop".
 
 <img src="https://firstcontributions.github.io/assets/gui-tool-tutorials/github-desktop-tutorial/dt1-clonetodesktop.png" alt="clone this repository" />
 
@@ -44,7 +44,7 @@ After that another dialogue box that says 'How are you planning to use this fork
 
 <img src="https://firstcontributions.github.io/assets/gui-tool-tutorials/github-desktop-tutorial/repository-clone-purpose.png" alt="Use of repository" height="500" />
 
-Now you have copied the contents of the first-contributions repository in github to your computer.
+Now you have copied the contents of the first-contributions repository on GitHub to your computer.
 
 ## Create a branch
 
@@ -66,7 +66,7 @@ Example: If your name is James Smith, It should look like this.
 
 \[James Smith](https://github.com/jamessmith)
 
-You can see that there are changes to Contributors.md and they have been added to the Github Desktop.
+You can see that there are changes to Contributors.md and they have been added to GitHub Desktop.
 
 <img src="https://firstcontributions.github.io/assets/gui-tool-tutorials/github-desktop-tutorial/dt1-status.png" alt="check status" />
 
@@ -84,11 +84,11 @@ At the bottom, you can see that the commit has been created.
 
 <img src="https://firstcontributions.github.io/assets/gui-tool-tutorials/github-desktop-tutorial/dt1-commit2.png" alt="commit your changes" />
 
-## Push changes to github
+## Push changes to GitHub
 
-Click on File->Options and sign-in to Github.com. Type in your Github username and password.
+Click on File->Options and sign-in to GitHub.com. Type in your GitHub username and password.
 
-<img src="https://firstcontributions.github.io/assets/gui-tool-tutorials/github-desktop-tutorial/dt1-sign-in.png" alt="log-in to Github" />
+<img src="https://firstcontributions.github.io/assets/gui-tool-tutorials/github-desktop-tutorial/dt1-sign-in.png" alt="log-in to GitHub" />
 
 Click the `Publish` button on the top right.
 
@@ -96,7 +96,7 @@ Click the `Publish` button on the top right.
 
 ## Submit your changes for review
 
-If you go to your repository on github, you'll see `Compare & pull request` button. click on that button.
+If you go to your repository on GitHub, you'll see `Compare & pull request` button. Click on that button.
 
 <img src="https://firstcontributions.github.io/assets/gui-tool-tutorials/github-desktop-tutorial/compare-and-pull.png" alt="create a pull request" />
 


### PR DESCRIPTION
## Summary
- `docs/gui-tool-tutorials/github-desktop-tutorial.md` had the "GitHub" brand name written inconsistently as "github" / "Github" in 8 places (headings, body text, and an image alt attribute), unlike the rest of the docs (e.g. `README.md`) which consistently capitalize it as "GitHub".
- Also fixed one sentence starting with a lowercase letter ("click on that button." -> "Click on that button.").

No content or instructions were changed, only capitalization/casing for consistency and correctness.

## Test plan
- [x] Diffed the change to confirm only capitalization/casing was touched, no wording or links changed