### PR TITLE
Add Lucas Correa Tavares to Contributors.md

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -4307,3 +4307,4 @@ jadav-sai-rugvedh_IMT2024051
 - [Obeida Arafa](https://github.com/o-arafa)
 - [Mythri](https://github.com/mythreddy03-svg)
 - [gmroberf](https://github.com/gmroberf)
+- [Lucas Correa Tavares](https://github.com/lucascorreatavares725-source)


### PR DESCRIPTION
## Summary
- Adding my name to Contributors.md as part of my first open source contribution/PR practice.