### PR TITLE
Add dindonaute-stack to Contributors list

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -4560,3 +4560,4 @@ Raphael Karani
 - [Adithyan H P](https://github.com/adithyanhp)
 - [MattyGT](https://github.com/MattyGT)
 - [AmalW](https://github.com/amalnc)
+- [dindonaute-stack](https://github.com/dindonaute-stack)


### PR DESCRIPTION
Adding my GitHub username to Contributors.md as part of my first contribution exercise.