### PR TITLE
Add Gaurav Jadhav to Contributors.md

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -4899,3 +4899,4 @@ Bobby Green
 - [darovio95-cmyk](https://github.com/darovio95-cmyk)
 - [aketada0729](https://github.com/aketada0729)
 - [Prabh gill](https://github.com/prabhtheone)
+- [Gaurav Jadhav](https://github.com/jadhavgaurav)


### PR DESCRIPTION
## Summary
- Adds my name and GitHub profile link to Contributors.md as part of the first-contributions exercise.

## Test plan
- N/A (documentation-only change to Contributors.md)