### PR TITLE
Add Joel Mastrian to Contributors list

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -18,6 +18,7 @@
 - [<GitHub naoyajojo>](https://github.com/<GitHub naoyajojo>)
 - Angshukana Haldar(https://github.com/Angs-8)
 - Sujeet Gupta
+- Joel Mastrian
 - Roberto de Oliveira Brito Filho
 - Sahil S
 - Millebisous


### PR DESCRIPTION
Added Joel Mastrian to the Contributors list as part of the First Contributions tutorial.