### PR TITLE
docs: add Emmanuel Maurice to contributors

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -4901,3 +4901,4 @@ abhinav abhinav
 - [Wilson Farrell Wirawan](https://github.com/wilfw)
   [Shivang Shukla](https://github.com/amshivang)
 - [razak31rl-ops](https://github.com/razak31rl-ops)
+- [Emmanuel Maurice](https://github.com/iamjellycoder )

--- a/Contributors.md
+++ b/Contributors.md
@@ -4917,3 +4917,4 @@ Bobby Green
 - [Wilson Farrell Wirawan](https://github.com/wilfw)
 [Shivang Shukla](https://github.com/amshivang)
 - [razak31rl-ops](https://github.com/razak31rl-ops)
+- [Emmanuel Maurice](https://github.com/iamjellycoder )


### PR DESCRIPTION
## Summary
- Added Emmanuel Maurice and the GitHub profile link to `Contributors.md`.

## Testing
- No tests were run because this is a documentation-only change.
