### PR TITLE
Fix broken markdown syntax in PR template instructions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,8 @@
-Before submitting this pull request, check the changes to see it's only the changes you made intentionally
+Before submitting this pull request, check the changes to see it's only the changes you made intentionally.
 If there are changes to other lines you didn't make deliberately, it's possible that your IDE made the changes with a utility like prettier.
 Next time, make sure that you only add your changes by using `git add -p` and rather than `git add Contributors.md`
 
-If you're doing something in the checklist below, put an `x` inside `[ ]` so that `- [ ]` becomes `- [x]`
+If you're doing something in the checklist below, put an `x` inside the brackets so that `- [ ]` becomes `- [x]`.
 
 - [ ] I had fun going through this tutorial (ノ^o^)ノ and learned on the way ٩(＾◡＾)۶
 - [ ] There are some things I'd like to improve in this tutorial. I have written them below.


### PR DESCRIPTION
The template on line 5 used standard quotes around  markdown brackets.This caused GitHub to hide symbols ,making the instruction s confusing .i wrapped the formatting symbols in backticks so they correctly as inline code snippets

Before submitting this pull request, check the changes to see it's only the changes you made intentionally
If there are changes to other lines you didn't make deliberately, it's possible that your IDE made the changes with a utility like prettier.
Next time, make sure that you only add your changes by using `git add -p` and rather than `git add Contributors.md`

If you're doing something in the checklist below, put an `x` inside `[ ]` so that `- [ ]` becomes `- [x]`

- [ ] I had fun going through this tutorial (ノ^o^)ノ and learned on the way ٩(＾◡＾)۶
- [ ] There are some things I'd like to improve in this tutorial. I have written them below.
- [ ] There were steps where I had errors while following this tutorial. I have written them below.